### PR TITLE
Fix node in-degree ignoring done predecessors in graph render (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: graph rendering now excludes done predecessors from a node's effective in-degree, so tasks whose only remaining blockers are already complete are shown as ready (#9)
+
 ## [0.7.0] - 2026-04-19
 
 - Add `dagdo sync` — optional cloud sync via any git remote

--- a/src/graph/dag.ts
+++ b/src/graph/dag.ts
@@ -23,6 +23,22 @@ export function buildActiveGraph(data: GraphData): AdjacencyGraph {
   return { tasks, inEdges, outEdges };
 }
 
+/**
+ * In-degree counting only unfinished predecessors — what the user cares about
+ * when deciding whether a task is actually ready. Done tasks do not block
+ * anything, so edges from done tasks are ignored for this purpose.
+ */
+export function effectiveInDegree(graph: AdjacencyGraph, id: TaskId): number {
+  const blockers = graph.inEdges.get(id);
+  if (!blockers) return 0;
+  let count = 0;
+  for (const fromId of blockers) {
+    const predecessor = graph.tasks.get(fromId);
+    if (predecessor && predecessor.doneAt == null) count++;
+  }
+  return count;
+}
+
 export function buildFullGraph(data: GraphData): AdjacencyGraph {
   const allIds = new Set(data.tasks.map((t) => t.id));
   const tasks = new Map(data.tasks.map((t) => [t.id, t]));

--- a/src/graph/render.ts
+++ b/src/graph/render.ts
@@ -1,6 +1,7 @@
 import pc from "picocolors";
 import type { AdjacencyGraph, GraphLayout, LayoutNode, LayoutEdge, TaskId, Priority } from "../types";
 import { topologicalSort } from "./topo";
+import { effectiveInDegree } from "./dag";
 
 /**
  * Compute the graph layout — pure data, no rendering.
@@ -15,7 +16,7 @@ export function computeLayout(graph: AdjacencyGraph): GraphLayout {
 
   for (const [id, task] of graph.tasks) {
     const level = levels.get(id) ?? 0;
-    const blocked = graph.inEdges.get(id)?.size ?? 0;
+    const blocked = effectiveInDegree(graph, id);
     const blocking = graph.outEdges.get(id)?.size ?? 0;
     nodes.push({ task, level, blocked, blocking });
 
@@ -141,9 +142,8 @@ export function renderMermaid(graph: AdjacencyGraph): string {
     } else {
       const tags = task.tags.length > 0 ? ` [${task.tags.join(", ")}]` : "";
       lines.push(`    ${id}("${task.title}${tags}")`);
-      // Check if ready (in-degree = 0 among active tasks)
-      const blockers = graph.inEdges.get(id);
-      const isReady = !blockers || blockers.size === 0;
+      // "Ready" means no unfinished predecessors — done blockers don't count.
+      const isReady = effectiveInDegree(graph, id) === 0;
       if (isReady) {
         readyIds.push(id);
       } else {

--- a/tests/dag.test.ts
+++ b/tests/dag.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { buildActiveGraph, wouldCreateCycle } from "../src/graph/dag";
+import { buildActiveGraph, buildFullGraph, effectiveInDegree, wouldCreateCycle } from "../src/graph/dag";
+import { computeLayout, renderMermaid } from "../src/graph/render";
 import type { GraphData } from "../src/types";
 
 function makeData(taskIds: string[], edges: [string, string][], doneIds: string[] = []): GraphData {
@@ -64,5 +65,43 @@ describe("wouldCreateCycle", () => {
     const graph = buildActiveGraph(data);
     // Adding a -> d is redundant but not a cycle
     expect(wouldCreateCycle(graph, "a", "d")).toBeNull();
+  });
+});
+
+describe("effectiveInDegree (issue #9)", () => {
+  // Scenario from the bug report: A -> B -> C, A marked done.
+  // B should be "ready" (effective in-degree = 0) because its only blocker is done.
+  it("treats done predecessors as non-blocking on the full graph", () => {
+    const data = makeData(["a", "b", "c"], [["a", "b"], ["b", "c"]], ["a"]);
+    const graph = buildFullGraph(data);
+    expect(effectiveInDegree(graph, "a")).toBe(0); // root
+    expect(effectiveInDegree(graph, "b")).toBe(0); // A done ⇒ B unblocked
+    expect(effectiveInDegree(graph, "c")).toBe(1); // still blocked by active B
+  });
+
+  it("counts multiple unfinished predecessors", () => {
+    // a -> c, b -> c with only a done
+    const data = makeData(["a", "b", "c"], [["a", "c"], ["b", "c"]], ["a"]);
+    const graph = buildFullGraph(data);
+    expect(effectiveInDegree(graph, "c")).toBe(1);
+  });
+
+  it("computeLayout surfaces effective blocked count", () => {
+    const data = makeData(["a", "b", "c"], [["a", "b"], ["b", "c"]], ["a"]);
+    const layout = computeLayout(buildFullGraph(data));
+    const byId = new Map(layout.nodes.map((n) => [n.task.id, n]));
+    expect(byId.get("b")!.blocked).toBe(0);
+    expect(byId.get("c")!.blocked).toBe(1);
+  });
+
+  it("renderMermaid styles B as ready (terracotta) when its blocker is done", () => {
+    const data = makeData(["a", "b", "c"], [["a", "b"], ["b", "c"]], ["a"]);
+    const mermaid = renderMermaid(buildFullGraph(data));
+    // terracotta fill marks ready nodes
+    expect(mermaid).toContain("style b fill:#c96442");
+    // blocked nodes use ivory
+    expect(mermaid).toContain("style c fill:#faf9f5");
+    // done nodes use muted gray
+    expect(mermaid).toContain("style a fill:#f0eee6");
   });
 });


### PR DESCRIPTION
Closes #9.

## Summary
- \`dagdo graph --all\` and \`dagdo view\` were coloring nodes as "blocked" (ivory) even when their only remaining predecessor was already done. The effective in-degree needs to count only **unfinished** predecessors.
- Adds \`effectiveInDegree(graph, id)\` in \`src/graph/dag.ts\` that walks \`inEdges\` and skips any whose source task has \`doneAt != null\`.
- \`computeLayout\` and \`renderMermaid\` switched to use it. \`renderAscii\` gets the fix for free via \`LayoutNode.blocked\`.
- \`list\` already had the correct behavior (line 37–44 filters done blockers explicitly); no change there.
- \`buildActiveGraph\` also already correct — it drops done tasks wholesale, so their edges never enter the graph.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun test\` — 38 pass (4 new tests covering the exact bug scenario: \`A→B→C\` with \`A\` done → \`B.blocked === 0\`, renderMermaid emits terracotta style for \`B\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)