### PR TITLE
Fix `dagdo view`: wrap SVG in HTML and broaden opener matrix (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: `dagdo view` now wraps the SVG in a minimal HTML page and opens it, so it reliably lands in a browser instead of whatever handler the OS has registered for `.svg`. Also adds Windows (`start`) to the opener matrix and a clearer error when `xdg-open` is missing on Linux (#12)
+
 ## [0.7.1] - 2026-04-19
 
 - Fix: graph rendering now excludes done predecessors from a node's effective in-degree, so tasks whose only remaining blockers are already complete are shown as ready (#9)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ dagdo graph --all --png graph.png  # PNG image with done tasks grayed out
 | `dagdo graph` | Visualize DAG (`--mermaid`, `--png <file>`, `--dot`, `--all`) |
 | `dagdo edit <id>` | Edit task (`--title`, `--priority`, `--tag`, `--untag`) |
 | `dagdo rm <id>` | Remove task and its edges |
-| `dagdo view` | Render full graph as PNG and open it |
+| `dagdo view` | Render full graph as SVG and open it in your browser |
 | `dagdo status` | Overview: total, done, ready, blocked |
 | `dagdo sync init <url>` | Configure cloud sync with a git remote |
 | `dagdo sync` | Sync global tasks (fast-forward; errors on divergence) |

--- a/skills/dagdo/SKILL.md
+++ b/skills/dagdo/SKILL.md
@@ -68,7 +68,7 @@ dagdo rm <id> [--force]
 ```bash
 dagdo view
 ```
-Renders the full graph (including done tasks) as a PNG and opens it with the system image viewer. A quick way to get a visual overview.
+Renders the full graph (including done tasks) as an SVG, wraps it in a minimal HTML page, and opens that HTML with the user's default browser. A quick way to get a zoomable visual overview.
 
 ### Status overview
 ```bash

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import { mkdirSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { graphCommand } from "./graph";
@@ -7,10 +7,72 @@ import { graphCommand } from "./graph";
 export async function viewCommand(): Promise<void> {
   const dir = join(tmpdir(), "dagdo-view");
   mkdirSync(dir, { recursive: true });
-  const file = join(dir, `dagdo-${Date.now()}.svg`);
 
-  await graphCommand(["--all", "--png", file]);
+  const stamp = Date.now();
+  const svgFile = join(dir, `dagdo-${stamp}.svg`);
+  const htmlFile = join(dir, `dagdo-${stamp}.html`);
 
-  const opener = process.platform === "darwin" ? "open" : "xdg-open";
-  execSync(`${opener} "${file}"`);
+  await graphCommand(["--all", "--png", svgFile]);
+
+  const svg = readFileSync(svgFile, "utf-8");
+  writeFileSync(htmlFile, wrapSvgInHtml(svg));
+
+  openFile(htmlFile);
+}
+
+/**
+ * Wrap an SVG string in a minimal HTML document so `dagdo view` always lands
+ * in a browser (where the graph is zoomable/scrollable) rather than whatever
+ * the OS has registered to handle the `.svg` extension (image viewer, Inkscape,
+ * editor, …).
+ */
+export function wrapSvgInHtml(svg: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>dagdo graph</title>
+<style>
+  html, body { margin: 0; padding: 0; background: #faf9f5; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; font-family: Georgia, serif; }
+  svg { max-width: 100vw; max-height: 100vh; height: auto; width: auto; }
+</style>
+</head>
+<body>
+${svg}
+</body>
+</html>
+`;
+}
+
+function openFile(path: string): void {
+  let command: string;
+  switch (process.platform) {
+    case "darwin":
+      command = `open "${path}"`;
+      break;
+    case "win32":
+      // `start ""` — the empty string is the window title, required so a quoted
+      // path isn't interpreted as the title.
+      command = `start "" "${path}"`;
+      break;
+    default:
+      command = `xdg-open "${path}"`;
+      break;
+  }
+
+  try {
+    execSync(command, { stdio: "ignore" });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (process.platform !== "darwin" && process.platform !== "win32") {
+      console.error(
+        `Failed to open ${path}: ${msg}\n` +
+          "Hint: xdg-open may not be installed. Install xdg-utils (apt: xdg-utils, dnf: xdg-utils) or open the file manually.",
+      );
+    } else {
+      console.error(`Failed to open ${path}: ${msg}`);
+    }
+    process.exit(1);
+  }
 }

--- a/tests/view.test.ts
+++ b/tests/view.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { wrapSvgInHtml } from "../src/commands/view";
+
+describe("wrapSvgInHtml", () => {
+  it("embeds the SVG inside a full HTML document", () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
+    const html = wrapSvgInHtml(svg);
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain("<title>dagdo graph</title>");
+    expect(html).toContain(svg);
+  });
+
+  it("does not double-escape SVG contents", () => {
+    // Arbitrary valid SVG-y characters (quotes, ampersands) must pass through
+    // unchanged so the browser renders them, rather than being HTML-escaped.
+    const svg = '<svg><text font-family="Georgia">A &amp; B</text></svg>';
+    const html = wrapSvgInHtml(svg);
+    expect(html).toContain(svg);
+  });
+});


### PR DESCRIPTION
Closes #12.

## Summary
- `dagdo view` emitted a raw `.svg` and passed it to the OS default handler, so depending on user settings it could open in Preview, Inkscape, or an editor — not a browser. Now it writes a small HTML wrapper containing the SVG inline and opens that, which is consistently registered to a browser on every platform.
- Adds `win32` (`start "" "<path>"`) to the opener matrix; previously Windows silently fell through to the Linux `xdg-open` branch.
- Linux now gives a clearer error when `xdg-open` is missing, pointing at `xdg-utils`.
- `wrapSvgInHtml` is extracted as a pure function and unit-tested.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 40 pass (2 new tests for the HTML wrapper)
- [ ] Manual smoke on each platform before shipping: run `dagdo view` and confirm a browser tab opens with the zoomable graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)