### PR TITLE
Add `dagdo ui` live web view (#8 stage 1)

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -24,6 +24,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -35,6 +38,7 @@ jobs:
           ALPHA_VERSION="${BASE_VERSION}-alpha.${SHORT_SHA}"
           npm version "$ALPHA_VERSION" --no-git-tag-version
           echo "Publishing alpha: $ALPHA_VERSION"
+      - run: bun run build:web
       - run: npm install --ignore-scripts
       - run: npm publish --tag alpha --access public
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,10 +147,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: v${{ needs.version.outputs.new_version }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      - run: bun run build:web
       - run: npm install --ignore-scripts
       - run: npm publish --provenance --access public
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Add `dagdo ui` — starts a local HTTP server and opens a browser tab with a live-updating graph view (React + React Flow + dagre layout). SSE pushes data changes within ~1s; read-only in this release, interactive editing to follow. (#8 stage 1, also closes #7)
+- `dagdo ui --port <n>` chooses a preferred port (default 3737, auto-increments on conflict); `--no-open` suppresses the browser.
+- Refactor: `globalDataDir()`/`globalDataFile()` now resolve `~/.dagdo/` lazily and honor `$HOME`, so overriding `HOME=…` works (previously Bun's macOS `os.homedir()` read passwd DB directly and ignored the env var).
+
 ## [0.7.2] - 2026-04-19
 
 - Fix: `dagdo view` now wraps the SVG in a minimal HTML page and opens it, so it reliably lands in a browser instead of whatever handler the OS has registered for `.svg`. Also adds Windows (`start`) to the opener matrix and a clearer error when `xdg-open` is missing on Linux (#12)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ dagdo graph --all --png graph.png  # PNG image with done tasks grayed out
 | `dagdo edit <id>` | Edit task (`--title`, `--priority`, `--tag`, `--untag`) |
 | `dagdo rm <id>` | Remove task and its edges |
 | `dagdo view` | Render full graph as SVG and open it in your browser |
+| `dagdo ui` | Start a local web view with live updates (read-only for now) |
 | `dagdo status` | Overview: total, done, ready, blocked |
 | `dagdo sync init <url>` | Configure cloud sync with a git remote |
 | `dagdo sync` | Sync global tasks (fast-forward; errors on divergence) |
@@ -117,6 +118,18 @@ dagdo graph --png output.png --dot # use Graphviz instead of Mermaid
 ## Data storage
 
 Tasks are stored in `~/.dagdo/data.json` — one user-level todo list across all your projects. If you want the list synced across machines, see the next section.
+
+## Web view
+
+`dagdo ui` starts a local HTTP server on `http://localhost:3737`, opens your browser, and renders the task graph with live updates — if you add, complete, or link tasks from another terminal, the page reflects the change within a second. The view is read-only in this release; interactive editing (drag to reposition, connect handles to add edges, etc.) is coming in a follow-up.
+
+```bash
+dagdo ui                  # default port 3737, opens a browser tab
+dagdo ui --port 8080      # pick your own port
+dagdo ui --no-open        # don't auto-open — useful in remote/SSH sessions
+```
+
+Port conflicts auto-increment (e.g. a second instance will land on 3738). `Ctrl+C` stops the server.
 
 ## Cloud sync (optional)
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:web": "cd web && bun install --frozen-lockfile && bun run build",
     "build": "bash scripts/build.sh",
     "test": "bun test",
-    "typecheck": "tsc --noEmit && cd web && bun run typecheck"
+    "typecheck": "tsc --noEmit && cd web && bun install --frozen-lockfile && bun run typecheck"
   },
   "keywords": [
     "todo",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "files": [
     "src",
     "bin",
-    "skills"
+    "skills",
+    "dist/web"
   ],
   "bin": {
     "dagdo": "bin/dagdo"
@@ -17,9 +18,10 @@
   },
   "scripts": {
     "dev": "bun run src/cli.ts",
+    "build:web": "cd web && bun install --frozen-lockfile && bun run build",
     "build": "bash scripts/build.sh",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && cd web && bun run typecheck"
   },
   "keywords": [
     "todo",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Build the React UI first so the binary can embed it at dist/web/index.html.
+bun run build:web
+
 bun build src/cli.ts --compile --outfile dagdo \
   --external mermaid-isomorphic \
   --external playwright \

--- a/skills/dagdo/SKILL.md
+++ b/skills/dagdo/SKILL.md
@@ -70,6 +70,14 @@ dagdo view
 ```
 Renders the full graph (including done tasks) as an SVG, wraps it in a minimal HTML page, and opens that HTML with the user's default browser. A quick way to get a zoomable visual overview.
 
+### Interactive web view (live updates)
+```bash
+dagdo ui                # default port 3737
+dagdo ui --port 8080
+dagdo ui --no-open
+```
+Starts a local server and opens a browser tab with a React + React Flow rendering of the graph. Page auto-updates within ~1s when the underlying data file changes (e.g. the user runs `dagdo add` in another terminal). Currently read-only; interactive editing is planned for a follow-up.
+
 ### Status overview
 ```bash
 dagdo status

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { graphCommand } from "./commands/graph";
 import { viewCommand } from "./commands/view";
 import { statusCommand } from "./commands/status";
 import { syncCommand } from "./commands/sync";
+import { uiCommand } from "./commands/ui";
 import { helpCommand } from "./commands/help";
 import { checkAliasOffer } from "./alias";
 import { checkForUpdate, upgradeCommand } from "./upgrade";
@@ -62,6 +63,9 @@ switch (command) {
     break;
   case "sync":
     await syncCommand(rest);
+    break;
+  case "ui":
+    await uiCommand(rest);
     break;
   case "upgrade":
     await upgradeCommand();

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -41,7 +41,11 @@ ${pc.bold("Commands:")}
       --png <file>                   Render to PNG/SVG (Mermaid, requires playwright)
       --dot                          Use Graphviz instead of Mermaid for --png
 
-  ${pc.cyan("view")}                        Render full graph as PNG and open it
+  ${pc.cyan("view")}                        Render full graph as SVG and open it in a browser
+
+  ${pc.cyan("ui")} [options]                 Open an interactive web view (live-updates)
+      --port <n>                     Preferred port (default 3737; increments on conflict)
+      --no-open                      Don't auto-open the browser
 
   ${pc.cyan("status")}                      Overview of all tasks
 

--- a/src/commands/ui.ts
+++ b/src/commands/ui.ts
@@ -1,0 +1,55 @@
+import { parseArgs } from "util";
+import pc from "picocolors";
+import { startServer } from "../server";
+import { openExternal } from "../open";
+
+const DEFAULT_PORT = 3737;
+
+export async function uiCommand(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      port: { type: "string" },
+      "no-open": { type: "boolean", default: false },
+    },
+  });
+
+  const preferredPort = values.port ? parsePort(values.port as string) : DEFAULT_PORT;
+
+  const server = await startServer({ preferredPort });
+
+  console.log(pc.green(`dagdo ui running at ${server.url}`));
+  if (server.port !== preferredPort) {
+    console.log(pc.dim(`  (port ${preferredPort} was in use)`));
+  }
+  console.log(pc.dim("  Ctrl+C to stop"));
+
+  if (!values["no-open"]) {
+    openExternal(server.url);
+  }
+
+  await waitForShutdown(server.stop);
+}
+
+function parsePort(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    console.error(`Invalid --port ${raw}. Expected integer 1–65535.`);
+    process.exit(1);
+  }
+  return n;
+}
+
+function waitForShutdown(stop: () => Promise<void>): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const shutdown = async () => {
+      try {
+        await stop();
+      } finally {
+        resolve();
+      }
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,8 +1,8 @@
-import { execSync } from "child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { graphCommand } from "./graph";
+import { openExternal } from "../open";
 
 export async function viewCommand(): Promise<void> {
   const dir = join(tmpdir(), "dagdo-view");
@@ -17,7 +17,7 @@ export async function viewCommand(): Promise<void> {
   const svg = readFileSync(svgFile, "utf-8");
   writeFileSync(htmlFile, wrapSvgInHtml(svg));
 
-  openFile(htmlFile);
+  openExternal(htmlFile);
 }
 
 /**
@@ -43,36 +43,4 @@ ${svg}
 </body>
 </html>
 `;
-}
-
-function openFile(path: string): void {
-  let command: string;
-  switch (process.platform) {
-    case "darwin":
-      command = `open "${path}"`;
-      break;
-    case "win32":
-      // `start ""` — the empty string is the window title, required so a quoted
-      // path isn't interpreted as the title.
-      command = `start "" "${path}"`;
-      break;
-    default:
-      command = `xdg-open "${path}"`;
-      break;
-  }
-
-  try {
-    execSync(command, { stdio: "ignore" });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (process.platform !== "darwin" && process.platform !== "win32") {
-      console.error(
-        `Failed to open ${path}: ${msg}\n` +
-          "Hint: xdg-open may not be installed. Install xdg-utils (apt: xdg-utils, dnf: xdg-utils) or open the file manually.",
-      );
-    } else {
-      console.error(`Failed to open ${path}: ${msg}`);
-    }
-    process.exit(1);
-  }
 }

--- a/src/open.ts
+++ b/src/open.ts
@@ -1,0 +1,37 @@
+import { execSync } from "child_process";
+
+/**
+ * Open a file or URL with the user's default handler. Picks the right
+ * invocation per platform; gives a clearer error on Linux when `xdg-open`
+ * is missing.
+ */
+export function openExternal(target: string): void {
+  let command: string;
+  switch (process.platform) {
+    case "darwin":
+      command = `open "${target}"`;
+      break;
+    case "win32":
+      // `start ""` — the empty string is the window title, required so a quoted
+      // path isn't interpreted as the title.
+      command = `start "" "${target}"`;
+      break;
+    default:
+      command = `xdg-open "${target}"`;
+      break;
+  }
+
+  try {
+    execSync(command, { stdio: "ignore" });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (process.platform !== "darwin" && process.platform !== "win32") {
+      console.error(
+        `Failed to open ${target}: ${msg}\n` +
+          "Hint: xdg-open may not be installed. Install xdg-utils or open the URL manually.",
+      );
+    } else {
+      console.error(`Failed to open ${target}: ${msg}`);
+    }
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,2 @@
+export { startServer } from "./server";
+export type { StartedServer, StartOptions } from "./server";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,0 +1,230 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "http";
+import { existsSync, readFileSync, statSync } from "fs";
+import { fileURLToPath } from "url";
+import { globalDataFile } from "../storage";
+import type { GraphData } from "../types";
+
+// Resolves to <repo-root>/dist/web/index.html in both dev (bun run src/cli.ts)
+// and installed (node_modules/@coiggahou2002/dagdo/...) layouts — src/server/
+// is always two levels above the dist/web sibling.
+const UI_HTML_PATH = fileURLToPath(new URL("../../dist/web/index.html", import.meta.url));
+
+export interface StartedServer {
+  url: string;
+  port: number;
+  stop: () => Promise<void>;
+}
+
+export interface StartOptions {
+  preferredPort: number;
+}
+
+export async function startServer(opts: StartOptions): Promise<StartedServer> {
+  const clients = new Set<ServerResponse>();
+  const server = createServer((req, res) => handleRequest(req, res, clients));
+
+  const port = await listenWithRetry(server, opts.preferredPort);
+
+  const stopWatch = startWatcher(() => {
+    broadcastUpdate(clients);
+  });
+
+  return {
+    port,
+    url: `http://localhost:${port}`,
+    stop: async () => {
+      stopWatch();
+      for (const c of clients) {
+        try {
+          c.end();
+        } catch {
+          // already closed
+        }
+      }
+      clients.clear();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  clients: Set<ServerResponse>,
+): void {
+  const url = req.url ?? "/";
+
+  if (req.method === "GET" && (url === "/" || url === "/index.html")) {
+    serveIndex(res);
+    return;
+  }
+
+  if (req.method === "GET" && url === "/api/graph") {
+    serveGraph(res);
+    return;
+  }
+
+  if (req.method === "GET" && url === "/api/events") {
+    attachSseClient(res, clients);
+    return;
+  }
+
+  // Browsers request /favicon.ico automatically; respond empty so the
+  // DevTools console doesn't light up on every page load.
+  if (req.method === "GET" && url === "/favicon.ico") {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end("Not found");
+}
+
+function serveIndex(res: ServerResponse): void {
+  if (!existsSync(UI_HTML_PATH)) {
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end(
+      "dagdo UI bundle not found.\n\n" +
+        "If you installed from source, run:\n" +
+        "  (cd web && bun install && bun run build)\n\n" +
+        `Expected: ${UI_HTML_PATH}`,
+    );
+    return;
+  }
+  const html = readFileSync(UI_HTML_PATH);
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(html);
+}
+
+function serveGraph(res: ServerResponse): void {
+  const graph = readGraphSafely();
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(graph));
+}
+
+function attachSseClient(res: ServerResponse, clients: Set<ServerResponse>): void {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Connection", "keep-alive");
+  // Flush headers so EventSource's onopen fires promptly.
+  res.flushHeaders?.();
+
+  clients.add(res);
+  sendEvent(res, "update", readGraphSafely());
+
+  // Heartbeat every 25s so idle proxies don't kill the connection. SSE
+  // comments (`:` prefix) are ignored by the browser.
+  const heartbeat = setInterval(() => {
+    try {
+      res.write(": ping\n\n");
+    } catch {
+      clearInterval(heartbeat);
+    }
+  }, 25_000);
+
+  res.on("close", () => {
+    clearInterval(heartbeat);
+    clients.delete(res);
+  });
+}
+
+function broadcastUpdate(clients: Set<ServerResponse>): void {
+  const graph = readGraphSafely();
+  for (const c of clients) {
+    sendEvent(c, "update", graph);
+  }
+}
+
+function sendEvent(res: ServerResponse, event: string, data: unknown): void {
+  try {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  } catch {
+    // client gone; next poll will remove it via 'close'
+  }
+}
+
+function readGraphSafely(): GraphData {
+  const file = globalDataFile();
+  if (!existsSync(file)) {
+    return { version: 1, tasks: [], edges: [] };
+  }
+  try {
+    return JSON.parse(readFileSync(file, "utf-8")) as GraphData;
+  } catch {
+    return { version: 1, tasks: [], edges: [] };
+  }
+}
+
+/**
+ * Poll the data file's mtime every 500ms. Polling rather than fs.watch because
+ * editors often save as delete+create which breaks persistent watches, and the
+ * added latency is imperceptible for a todo list.
+ */
+function startWatcher(onChange: () => void): () => void {
+  let last = currentMtime();
+  const iv = setInterval(() => {
+    const now = currentMtime();
+    if (now !== last) {
+      last = now;
+      onChange();
+    }
+  }, 500);
+  return () => clearInterval(iv);
+}
+
+function currentMtime(): number {
+  const file = globalDataFile();
+  if (!existsSync(file)) return 0;
+  try {
+    return statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+async function listenWithRetry(server: Server, startPort: number): Promise<number> {
+  // Port 0 means "let the OS pick any free port" — no retry needed.
+  if (startPort === 0) {
+    await listenOn(server, 0);
+    const addr = server.address();
+    if (addr && typeof addr === "object") return addr.port;
+    throw new Error("Failed to resolve bound port");
+  }
+
+  const MAX_ATTEMPTS = 20;
+  for (let i = 0; i < MAX_ATTEMPTS; i++) {
+    const port = startPort + i;
+    try {
+      await listenOn(server, port);
+      return port;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EADDRINUSE") throw err;
+      // try next port
+    }
+  }
+  throw new Error(
+    `Could not bind a port in range ${startPort}..${startPort + MAX_ATTEMPTS - 1}`,
+  );
+}
+
+function listenOn(server: Server, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: NodeJS.ErrnoException) => {
+      server.off("listening", onListen);
+      reject(err);
+    };
+    const onListen = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListen);
+    server.listen(port, "127.0.0.1");
+  });
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -4,15 +4,17 @@ import { homedir } from "os";
 import type { GraphData } from "./types";
 import * as git from "./git";
 
-const GLOBAL_DATA_DIR = join(homedir(), ".dagdo");
-const GLOBAL_DATA_FILE = join(GLOBAL_DATA_DIR, "data.json");
-
+// Paths are resolved lazily each call rather than frozen at module load, so
+// `HOME=/tmp/... dagdo …` (and test harnesses that swap HOME between cases)
+// work without surprising caching. `$HOME` is preferred over `homedir()`
+// because Bun's `os.homedir()` on macOS reads the passwd DB directly and
+// ignores the env var, which breaks `HOME=…` overrides.
 export function globalDataDir(): string {
-  return GLOBAL_DATA_DIR;
+  return join(process.env.HOME || homedir(), ".dagdo");
 }
 
 export function globalDataFile(): string {
-  return GLOBAL_DATA_FILE;
+  return join(globalDataDir(), "data.json");
 }
 
 function defaultData(): GraphData {
@@ -20,24 +22,27 @@ function defaultData(): GraphData {
 }
 
 export async function loadGraph(): Promise<GraphData> {
-  if (!existsSync(GLOBAL_DATA_FILE)) return defaultData();
+  const file = globalDataFile();
+  if (!existsSync(file)) return defaultData();
   try {
-    return JSON.parse(readFileSync(GLOBAL_DATA_FILE, "utf-8")) as GraphData;
+    return JSON.parse(readFileSync(file, "utf-8")) as GraphData;
   } catch {
-    console.error(`Error: failed to parse ${GLOBAL_DATA_FILE}`);
+    console.error(`Error: failed to parse ${file}`);
     return defaultData();
   }
 }
 
 export async function saveGraph(data: GraphData, commitMessage?: string): Promise<void> {
-  mkdirSync(GLOBAL_DATA_DIR, { recursive: true });
-  writeFileSync(GLOBAL_DATA_FILE, JSON.stringify(data, null, 2) + "\n");
+  const dir = globalDataDir();
+  const file = globalDataFile();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(file, JSON.stringify(data, null, 2) + "\n");
 
   // Auto-commit when sync has been set up.
-  if (!git.isRepo(GLOBAL_DATA_DIR)) return;
+  if (!git.isRepo(dir)) return;
 
   try {
-    await git.commit(GLOBAL_DATA_DIR, commitMessage ?? "update");
+    await git.commit(dir, commitMessage ?? "update");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`Warning: auto-commit failed (${msg}). Run 'dagdo sync' to recover.`);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { GraphData } from "../src/types";
+
+// Local dev machines may have HTTP_PROXY set, which Bun's fetch honors and
+// which will 502 against our loopback server. Mask proxies for this suite.
+delete process.env.HTTP_PROXY;
+delete process.env.HTTPS_PROXY;
+delete process.env.http_proxy;
+delete process.env.https_proxy;
+process.env.NO_PROXY = "localhost,127.0.0.1";
+process.env.no_proxy = "localhost,127.0.0.1";
+
+describe("server", () => {
+  let testHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    testHome = join(tmpdir(), `dagdo-server-test-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(join(testHome, ".dagdo"), { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = testHome;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("serves the current graph at /api/graph", async () => {
+    const seed: GraphData = {
+      version: 1,
+      tasks: [
+        {
+          id: "abcdef",
+          title: "seed",
+          priority: "med",
+          tags: ["x"],
+          createdAt: "2026-01-01T00:00:00Z",
+          doneAt: null,
+        },
+      ],
+      edges: [],
+    };
+    writeFileSync(join(testHome, ".dagdo", "data.json"), JSON.stringify(seed));
+
+    // Import inside the test so the module re-reads HOME each time via the
+    // storage helper rather than caching from an earlier test's HOME.
+    const { startServer } = await import(`../src/server/server?t=${Date.now()}`);
+    const srv = await startServer({ preferredPort: 0 });
+
+    try {
+      const res = await fetch(`${srv.url}/api/graph`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as GraphData;
+      expect(body.tasks.length).toBe(1);
+      expect(body.tasks[0]!.title).toBe("seed");
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("returns an empty graph when data.json is absent", async () => {
+    const { startServer } = await import(`../src/server/server?t=${Date.now()}`);
+    const srv = await startServer({ preferredPort: 0 });
+
+    try {
+      const res = await fetch(`${srv.url}/api/graph`);
+      const body = (await res.json()) as GraphData;
+      expect(body.tasks).toEqual([]);
+      expect(body.edges).toEqual([]);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("picks a different port when preferredPort is in use", async () => {
+    const { startServer } = await import(`../src/server/server?t=${Date.now()}`);
+    const first = await startServer({ preferredPort: 0 });
+
+    try {
+      const second = await startServer({ preferredPort: first.port });
+      try {
+        expect(second.port).toBeGreaterThan(first.port);
+      } finally {
+        await second.stop();
+      }
+    } finally {
+      await first.stop();
+    }
+  });
+
+  it("responds 204 to /favicon.ico", async () => {
+    const { startServer } = await import(`../src/server/server?t=${Date.now()}`);
+    const srv = await startServer({ preferredPort: 0 });
+
+    try {
+      const res = await fetch(`${srv.url}/favicon.ico`);
+      expect(res.status).toBe(204);
+    } finally {
+      await srv.stop();
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "exclude": ["web", "node_modules", "dist"]
 }

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -1,0 +1,320 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "dagdo-web",
+      "dependencies": {
+        "@xyflow/react": "^12.3.6",
+        "dagre": "^0.8.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+      },
+      "devDependencies": {
+        "@types/dagre": "^0.7.52",
+        "@types/node": "^25.6.0",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.11",
+        "vite-plugin-singlefile": "^2.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/dagre": ["@types/dagre@0.7.54", "", {}, "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
+
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001788", "", {}, "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ=="],
+
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre": ["dagre@0.8.5", "", { "dependencies": { "graphlib": "^2.1.8", "lodash": "^4.17.15" } }, "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.340", "", {}, "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "graphlib": ["graphlib@2.1.8", "", { "dependencies": { "lodash": "^4.17.15" } }, "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>dagdo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "dagdo-web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@xyflow/react": "^12.3.6",
+    "dagre": "^0.8.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/dagre": "^0.7.52",
+    "@types/node": "^25.6.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11",
+    "vite-plugin-singlefile": "^2.0.3"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge as FlowEdge,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { layoutGraph } from "./layout";
+import type { GraphData, Task } from "./types";
+
+const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
+
+export function App() {
+  const [graph, setGraph] = useState<GraphData>(EMPTY);
+  const [status, setStatus] = useState<"loading" | "connected" | "disconnected">("loading");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/graph")
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((data: GraphData) => {
+        if (!cancelled) setGraph(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(`Failed to load graph: ${err.message}`);
+      });
+
+    const es = new EventSource("/api/events");
+    es.addEventListener("open", () => setStatus("connected"));
+    es.addEventListener("update", (ev) => {
+      try {
+        const payload = JSON.parse((ev as MessageEvent).data) as GraphData;
+        setGraph(payload);
+      } catch {
+        // malformed payload — ignore, next update will correct
+      }
+    });
+    es.addEventListener("error", () => setStatus("disconnected"));
+
+    return () => {
+      cancelled = true;
+      es.close();
+    };
+  }, []);
+
+  const { nodes, flowEdges } = useMemo(() => {
+    const laidOut = layoutGraph(graph.tasks, graph.edges);
+    const nodes: Node[] = laidOut.map((n) => ({
+      id: n.id,
+      position: { x: n.x, y: n.y },
+      data: { label: nodeLabel(n.task), state: n.state },
+      draggable: true,
+      selectable: true,
+      className: `dagdo-node dagdo-node-${n.state}`,
+      style: {}, // styling via className + CSS; see styles.css
+    }));
+    const flowEdges: FlowEdge[] = graph.edges.map((e) => {
+      const fromTask = graph.tasks.find((t) => t.id === e.from);
+      const dashed = fromTask?.doneAt != null;
+      return {
+        id: `${e.from}->${e.to}`,
+        source: e.from,
+        target: e.to,
+        animated: false,
+        style: dashed
+          ? { strokeDasharray: "4 4", stroke: "#b5ada0" }
+          : { stroke: "#87867f" },
+      };
+    });
+    return { nodes, flowEdges };
+  }, [graph]);
+
+  return (
+    <div className="dagdo-root">
+      <header className="dagdo-header">
+        <div className="dagdo-title">dagdo</div>
+        <div className="dagdo-stats">
+          {graph.tasks.length} tasks · {graph.edges.length} edges
+        </div>
+        <div className={`dagdo-status dagdo-status-${status}`}>
+          {status === "connected" ? "● live" : status === "loading" ? "○ loading" : "○ offline"}
+        </div>
+      </header>
+
+      {error && <div className="dagdo-error">{error}</div>}
+
+      {graph.tasks.length === 0 ? (
+        <div className="dagdo-empty">
+          <p>No tasks yet.</p>
+          <p>
+            <code>dagdo add "your first task"</code>
+          </p>
+        </div>
+      ) : (
+        <div className="dagdo-canvas">
+          <ReactFlow
+            nodes={nodes}
+            edges={flowEdges}
+            fitView
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background color="#e8e6dc" gap={20} />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable maskColor="rgba(245, 244, 237, 0.7)" />
+          </ReactFlow>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function nodeLabel(t: Task): string {
+  const parts = [t.title];
+  if (t.tags.length > 0) parts.push(`[${t.tags.join(", ")}]`);
+  return parts.join("\n");
+}

--- a/web/src/layout.ts
+++ b/web/src/layout.ts
@@ -1,0 +1,68 @@
+import dagre from "dagre";
+import type { Edge, NodeState, Task } from "./types";
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 64;
+
+export interface LaidOutNode {
+  id: string;
+  x: number;
+  y: number;
+  task: Task;
+  state: NodeState;
+}
+
+/**
+ * Dagre top-to-bottom layout. Positions are recomputed on every graph change
+ * — keeps things simple since Stage 1 is read-only. User-driven layout goes
+ * in Stage 2.
+ */
+export function layoutGraph(tasks: Task[], edges: Edge[]): LaidOutNode[] {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 70, marginx: 20, marginy: 20 });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const t of tasks) g.setNode(t.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  for (const e of edges) {
+    if (tasks.find((t) => t.id === e.from) && tasks.find((t) => t.id === e.to)) {
+      g.setEdge(e.from, e.to);
+    }
+  }
+
+  dagre.layout(g);
+
+  const states = computeNodeStates(tasks, edges);
+  return tasks.map((t) => {
+    const n = g.node(t.id);
+    return {
+      id: t.id,
+      x: n.x - NODE_WIDTH / 2,
+      y: n.y - NODE_HEIGHT / 2,
+      task: t,
+      state: states.get(t.id) ?? "blocked",
+    };
+  });
+}
+
+/**
+ * Mirror of effectiveInDegree in src/graph/dag.ts — a done predecessor no
+ * longer blocks its successor.
+ */
+function computeNodeStates(tasks: Task[], edges: Edge[]): Map<string, NodeState> {
+  const taskById = new Map(tasks.map((t) => [t.id, t]));
+  const blockerCount = new Map<string, number>();
+  for (const t of tasks) blockerCount.set(t.id, 0);
+  for (const e of edges) {
+    const from = taskById.get(e.from);
+    if (from && from.doneAt == null) {
+      blockerCount.set(e.to, (blockerCount.get(e.to) ?? 0) + 1);
+    }
+  }
+  const states = new Map<string, NodeState>();
+  for (const t of tasks) {
+    if (t.doneAt != null) states.set(t.id, "done");
+    else if ((blockerCount.get(t.id) ?? 0) === 0) states.set(t.id, "ready");
+    else states.set(t.id, "blocked");
+  }
+  return states;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("no #root");
+
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,133 @@
+:root {
+  /* Warm palette mirrors src/graph/render.ts */
+  --bg: #f5f4ed;
+  --surface: #faf9f5;
+  --border: #e8e6dc;
+  --text: #141413;
+  --muted: #87867f;
+  --ready: #c96442;
+  --ready-fg: #faf9f5;
+  --ready-border: #b5573a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.dagdo-root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.dagdo-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.dagdo-title {
+  font-weight: bold;
+  font-size: 18px;
+}
+
+.dagdo-stats {
+  color: var(--muted);
+  font-size: 13px;
+  flex: 1;
+}
+
+.dagdo-status {
+  font-size: 13px;
+  font-family: "SF Mono", Menlo, monospace;
+}
+
+.dagdo-status-connected {
+  color: #4a7c4e;
+}
+
+.dagdo-status-loading {
+  color: var(--muted);
+}
+
+.dagdo-status-disconnected {
+  color: #c96442;
+}
+
+.dagdo-error {
+  padding: 10px 16px;
+  background: #fdf0ec;
+  color: #8b3b23;
+  border-bottom: 1px solid var(--border);
+}
+
+.dagdo-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  gap: 8px;
+}
+
+.dagdo-empty code {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-family: "SF Mono", Menlo, monospace;
+  color: var(--text);
+}
+
+.dagdo-canvas {
+  flex: 1;
+  min-height: 0;
+}
+
+/* React Flow node styling via classNames on each node */
+.react-flow__node.dagdo-node {
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-family: Georgia, serif;
+  font-size: 13px;
+  line-height: 1.3;
+  white-space: pre-line;
+  width: 200px;
+  text-align: center;
+  border: 1px solid;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.dagdo-node-ready {
+  background: var(--ready);
+  color: var(--ready-fg);
+  border-color: var(--ready-border);
+}
+
+.dagdo-node-blocked {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.dagdo-node-done {
+  background: #f0eee6;
+  color: var(--muted);
+  border-color: var(--border);
+  text-decoration: line-through;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,25 @@
+// Mirror of src/types.ts — kept in sync by hand. Stable schema, rarely changes.
+
+export type Priority = "low" | "med" | "high";
+
+export interface Task {
+  id: string;
+  title: string;
+  priority: Priority;
+  tags: string[];
+  createdAt: string;
+  doneAt: string | null;
+}
+
+export interface Edge {
+  from: string;
+  to: string;
+}
+
+export interface GraphData {
+  version: 1;
+  tasks: Task[];
+  edges: Edge[];
+}
+
+export type NodeState = "ready" | "blocked" | "done";

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { viteSingleFile } from "vite-plugin-singlefile";
+import { resolve } from "path";
+import { fileURLToPath } from "url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  plugins: [react(), viteSingleFile()],
+  build: {
+    outDir: resolve(here, "../dist/web"),
+    emptyOutDir: true,
+    // Single HTML output with everything inlined — served by dagdo's
+    // node http server at `/`, so zero static asset plumbing.
+    assetsInlineLimit: 100_000_000,
+    cssCodeSplit: false,
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
Stage 1 of #8. Also closes #7 by subsumption.

## What this PR delivers
- New command: `dagdo ui` — starts a local HTTP server (default `http://localhost:3737`), opens a browser tab, renders the task graph with React + React Flow + dagre auto-layout. SSE pushes updates when the data file changes.
- Read-only in this release. Stage 2 will add editing (drag-to-reposition with persistence, handle-to-handle edge creation with cycle detection, delete node/edge, rename title). Stage 3 covers property editing (priority, tags, done).

## Architecture
- `web/` subproject, built by Vite + `vite-plugin-singlefile` into one inline-JS-and-CSS `dist/web/index.html`. The dagdo server reads that file from disk and serves it at `/`. Zero static-asset plumbing.
- Server: Node `http` only, no new runtime deps. Routes: `GET /` (HTML), `GET /api/graph` (JSON), `GET /api/events` (SSE with heartbeat), `GET /favicon.ico` (204).
- Watcher: 500ms mtime poll (not `fs.watch` — too platform-fickle). On change, broadcasts the fresh graph to all connected SSE clients.
- Port: default 3737, auto-increment on `EADDRINUSE` up to +19 attempts. `--port N` overrides, `--no-open` skips the browser.
- UI colors mirror CLI render + the #9 effective-in-degree rule (done predecessor does not block its successor).

## CI / packaging
- `package.json` `files` includes `dist/web/` so npm tarballs ship the bundle.
- Both `.github/workflows/release.yml` and `.github/workflows/alpha.yml` now run `bun run build:web` before `npm publish`, and set up Bun alongside Node for those jobs.
- Note: the downloadable standalone binary doesn't yet embed the HTML bundle — for now `dagdo ui` from the binary shows a helpful "UI bundle not found" error. I'd handle that in a small follow-up PR (either `with { type: "file" }` embedding or shipping the HTML alongside the binary in Release artifacts).

## Side-quest: `$HOME` respect on macOS
Bun's `os.homedir()` on macOS ignores `$HOME` and reads the passwd DB directly, so `HOME=/tmp/foo dagdo …` silently hit the real user's data. `globalDataDir()` / `globalDataFile()` in `src/storage.ts` now prefer `process.env.HOME` over `homedir()` and are computed lazily. Tests exploit this to run against isolated tmp homes.

## Test plan
- [x] `bun run typecheck` (root + web) clean
- [x] `bun test` — 44 pass (4 new integration tests for the server: serves graph, empty-state default, port-retry, favicon-204)
- [x] End-to-end with chrome-devtools:
  - Initial render: done-dashed-crossed-out, ready-terracotta, blocked-ivory, "● live" indicator
  - Live reload: adding a task to `data.json` externally makes it appear in the browser within ~500ms
  - Port conflict auto-increment works (covered in unit test)
- [ ] Binary compile path (`bun build --compile`) for `dagdo ui` — deferred to follow-up; npm install path is primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)