### PR TITLE
Property panel for dagdo ui (#8 stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- `dagdo ui` gains a property panel: click a node to open a sidebar with priority selector (high/med/low), tag chips with add/remove, a "mark as done" checkbox, and a delete button for discoverability. Each node now also shows a small priority dot so the canvas remains scannable with the panel closed. (#8 stage 3 — closes #8)
+
 ## [0.9.0] - 2026-04-19
 
 - `dagdo ui` is now interactive: drag nodes to rearrange, handle-to-handle drag to create dependencies (server-side cycle check, 409 → toast on conflict), select + `Delete` removes nodes/edges, double-click to rename a title, **+ New task** button adds a task. Positions are session-only, deliberately not persisted. (#8 stage 2)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Tasks are stored in `~/.dagdo/data.json` — one user-level todo list across all
 
 ## Web view
 
-`dagdo ui` starts a local HTTP server on `http://localhost:3737`, opens your browser, and renders an interactive task graph. CLI changes from other terminals appear within a second; the browser can also edit: drag nodes to rearrange, drag from one node's bottom handle to another's top to create a dependency (with cycle detection), select a node/edge and press `Delete` to remove it, double-click a node title to rename it, and use the **+ New task** button in the header to add one.
+`dagdo ui` starts a local HTTP server on `http://localhost:3737`, opens your browser, and renders an interactive task graph. CLI changes from other terminals appear within a second; the browser can also edit: drag nodes to rearrange, drag from one node's bottom handle to another's top to create a dependency (with cycle detection), select a node/edge and press `Delete` to remove it, double-click a node title to rename it, and use the **+ New task** button in the header to add one. Click a node to open the property panel on the right — change priority, add/remove tags, or mark the task done.
 
 ```bash
 dagdo ui                  # default port 3737, opens a browser tab

--- a/skills/dagdo/SKILL.md
+++ b/skills/dagdo/SKILL.md
@@ -76,7 +76,7 @@ dagdo ui                # default port 3737
 dagdo ui --port 8080
 dagdo ui --no-open
 ```
-Starts a local server and opens a browser tab with a React + React Flow rendering of the graph. Supports: drag to reposition nodes (ephemeral — positions are not persisted), drag handle-to-handle to create dependencies (cycle-checked server-side, rejected with a toast on conflict), select + `Delete` to remove nodes or edges, double-click title to rename, **+ New task** button to add. All mutations go through the same `~/.dagdo/data.json` that the CLI writes, so CLI edits and UI edits converge automatically.
+Starts a local server and opens a browser tab with a React + React Flow rendering of the graph. Supports: drag to reposition nodes (ephemeral — positions are not persisted), drag handle-to-handle to create dependencies (cycle-checked server-side, rejected with a toast on conflict), select + `Delete` to remove nodes or edges, double-click title to rename, **+ New task** button to add. Click a node to open a property panel: change priority, add/remove tags, mark as done, or delete. Each node shows a small priority dot (high=terracotta / med=gray / low=muted). All mutations go through the same `~/.dagdo/data.json` that the CLI writes, so CLI edits and UI edits converge automatically.
 
 ### Status overview
 ```bash

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,8 +15,17 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { layoutGraph } from "./layout";
-import { ApiError, createEdge, createTask, deleteEdge, deleteTask, updateTask } from "./api";
+import {
+  ApiError,
+  createEdge,
+  createTask,
+  deleteEdge,
+  deleteTask,
+  updateTask,
+  type TaskPatch,
+} from "./api";
 import { TaskNode, type TaskNodeData } from "./TaskNode";
+import { PropertyPanel } from "./PropertyPanel";
 import type { GraphData } from "./types";
 
 const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
@@ -32,6 +41,7 @@ export function App() {
   const [toast, setToast] = useState<Toast>(null);
   const [nodes, setNodes] = useState<FlowNode<TaskNodeData>[]>([]);
   const [edges, setEdges] = useState<FlowEdge[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   // IDs of nodes the user has manually dragged — their positions should survive
   // SSE-driven rebuilds rather than snapping back to the dagre layout. Pristine
@@ -76,6 +86,12 @@ export function App() {
     });
   }, []);
 
+  const handlePatch = useCallback((id: string, patch: TaskPatch) => {
+    updateTask(id, patch).catch((err: unknown) => {
+      showToast({ kind: "error", text: formatError("Update failed", err) });
+    });
+  }, []);
+
   // ─── reconcile Flow state whenever server state changes ──────────────
   useEffect(() => {
     const autoLayout = layoutGraph(graph.tasks, graph.edges);
@@ -95,6 +111,7 @@ export function App() {
           id: task.id,
           type: "task",
           position: preserved ?? autoPos,
+          selected: selectedId === task.id,
           data: {
             task,
             state: auto?.state ?? "blocked",
@@ -110,6 +127,11 @@ export function App() {
     const aliveIds = new Set(graph.tasks.map((t) => t.id));
     for (const id of userPositioned.current) {
       if (!aliveIds.has(id)) userPositioned.current.delete(id);
+    }
+    // If the selected task was removed elsewhere, drop the selection so the
+    // panel closes rather than lingering on stale data.
+    if (selectedId && !aliveIds.has(selectedId)) {
+      setSelectedId(null);
     }
 
     setEdges(
@@ -127,7 +149,7 @@ export function App() {
         };
       }),
     );
-  }, [graph, handleRename]);
+  }, [graph, handleRename, selectedId]);
 
   // ─── React Flow event handlers ───────────────────────────────────────
   const onNodesChange = useCallback((changes: NodeChange[]) => {
@@ -174,6 +196,17 @@ export function App() {
     }
   }, []);
 
+  const onNodeClick = useCallback<NonNullable<React.ComponentProps<typeof ReactFlow>["onNodeClick"]>>(
+    (_event, node) => {
+      setSelectedId(node.id);
+    },
+    [],
+  );
+
+  const onPaneClick = useCallback(() => {
+    setSelectedId(null);
+  }, []);
+
   // ─── "add task" button ───────────────────────────────────────────────
   const onAddTask = useCallback(async () => {
     const title = window.prompt("New task title:");
@@ -203,6 +236,11 @@ export function App() {
     return { total: graph.tasks.length, done };
   }, [graph]);
 
+  const selectedTask = useMemo(
+    () => (selectedId ? graph.tasks.find((t) => t.id === selectedId) ?? null : null),
+    [selectedId, graph.tasks],
+  );
+
   return (
     <div className="dagdo-root">
       <header className="dagdo-header">
@@ -224,34 +262,52 @@ export function App() {
         </div>
       )}
 
-      {graph.tasks.length === 0 ? (
-        <div className="dagdo-empty">
-          <p>No tasks yet.</p>
-          <button className="dagdo-add-button" onClick={onAddTask}>
-            + Add your first task
-          </button>
-        </div>
-      ) : (
-        <div className="dagdo-canvas">
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            nodeTypes={NODE_TYPES}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onNodeDragStop={onNodeDragStop}
-            onConnect={onConnect}
-            onEdgesDelete={onEdgesDelete}
-            onNodesDelete={onNodesDelete}
-            fitView
-            proOptions={{ hideAttribution: true }}
-          >
-            <Background color="#e8e6dc" gap={20} />
-            <Controls showInteractive={false} />
-            <MiniMap pannable zoomable maskColor="rgba(245, 244, 237, 0.7)" />
-          </ReactFlow>
-        </div>
-      )}
+      <div className="dagdo-body">
+        {graph.tasks.length === 0 ? (
+          <div className="dagdo-empty">
+            <p>No tasks yet.</p>
+            <button className="dagdo-add-button" onClick={onAddTask}>
+              + Add your first task
+            </button>
+          </div>
+        ) : (
+          <div className="dagdo-canvas">
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              nodeTypes={NODE_TYPES}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onNodeDragStop={onNodeDragStop}
+              onConnect={onConnect}
+              onEdgesDelete={onEdgesDelete}
+              onNodesDelete={onNodesDelete}
+              onNodeClick={onNodeClick}
+              onPaneClick={onPaneClick}
+              fitView
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background color="#e8e6dc" gap={20} />
+              <Controls showInteractive={false} />
+              <MiniMap pannable zoomable maskColor="rgba(245, 244, 237, 0.7)" />
+            </ReactFlow>
+          </div>
+        )}
+
+        {selectedTask && (
+          <PropertyPanel
+            task={selectedTask}
+            onChange={(patch) => handlePatch(selectedTask.id, patch)}
+            onDelete={() => {
+              deleteTask(selectedTask.id).catch((err: unknown) => {
+                showToast({ kind: "error", text: formatError("Delete failed", err) });
+              });
+              setSelectedId(null);
+            }}
+            onClose={() => setSelectedId(null)}
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -274,4 +330,3 @@ function formatError(prefix: string, err: unknown): string {
   if (err instanceof Error) return `${prefix}: ${err.message}`;
   return `${prefix}.`;
 }
-

--- a/web/src/PropertyPanel.tsx
+++ b/web/src/PropertyPanel.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState, type KeyboardEvent } from "react";
+import type { Priority, Task } from "./types";
+
+interface PropertyPanelProps {
+  task: Task;
+  onChange: (patch: { priority?: Priority; tags?: string[]; doneAt?: string | null }) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+const PRIORITIES: Priority[] = ["high", "med", "low"];
+
+export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPanelProps) {
+  const [tagDraft, setTagDraft] = useState("");
+
+  // Reset the tag draft when switching between tasks so input doesn't leak.
+  useEffect(() => {
+    setTagDraft("");
+  }, [task.id]);
+
+  function addTag(raw: string): void {
+    const tag = raw.trim();
+    if (tag.length === 0) return;
+    if (task.tags.includes(tag)) return;
+    onChange({ tags: [...task.tags, tag] });
+    setTagDraft("");
+  }
+
+  function removeTag(tag: string): void {
+    onChange({ tags: task.tags.filter((t) => t !== tag) });
+  }
+
+  function onTagKeyDown(e: KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag(tagDraft);
+    } else if (e.key === "Escape") {
+      setTagDraft("");
+    }
+  }
+
+  const done = task.doneAt != null;
+
+  return (
+    <aside className="dagdo-panel">
+      <div className="dagdo-panel-head">
+        <span className="dagdo-panel-title">Task</span>
+        <button className="dagdo-panel-close" onClick={onClose} aria-label="Close panel">
+          ✕
+        </button>
+      </div>
+
+      <div className="dagdo-panel-row">
+        <div className="dagdo-panel-label">Title</div>
+        <div className="dagdo-panel-value dagdo-panel-title-readonly">{task.title}</div>
+        <div className="dagdo-panel-hint">Double-click the node to rename.</div>
+      </div>
+
+      <div className="dagdo-panel-row">
+        <div className="dagdo-panel-label">Priority</div>
+        <div className="dagdo-panel-segmented">
+          {PRIORITIES.map((p) => (
+            <button
+              key={p}
+              className={`dagdo-panel-seg ${task.priority === p ? "is-active" : ""} dagdo-panel-seg-${p}`}
+              onClick={() => {
+                if (task.priority !== p) onChange({ priority: p });
+              }}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="dagdo-panel-row">
+        <div className="dagdo-panel-label">Tags</div>
+        <div className="dagdo-panel-tags">
+          {task.tags.map((tag) => (
+            <span key={tag} className="dagdo-chip">
+              {tag}
+              <button
+                className="dagdo-chip-remove"
+                onClick={() => removeTag(tag)}
+                aria-label={`Remove tag ${tag}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {task.tags.length === 0 && <span className="dagdo-panel-empty">no tags</span>}
+        </div>
+        <input
+          className="dagdo-panel-input"
+          placeholder="add tag (Enter)"
+          value={tagDraft}
+          onChange={(e) => setTagDraft(e.target.value)}
+          onKeyDown={onTagKeyDown}
+          onBlur={() => addTag(tagDraft)}
+        />
+      </div>
+
+      <div className="dagdo-panel-row">
+        <label className="dagdo-panel-checkbox">
+          <input
+            type="checkbox"
+            checked={done}
+            onChange={(e) => onChange({ doneAt: e.target.checked ? new Date().toISOString() : null })}
+          />
+          <span>Mark as done</span>
+        </label>
+        {done && task.doneAt && (
+          <div className="dagdo-panel-hint">Completed {formatDate(task.doneAt)}</div>
+        )}
+      </div>
+
+      <div className="dagdo-panel-row">
+        <div className="dagdo-panel-label">Created</div>
+        <div className="dagdo-panel-value dagdo-panel-created">{formatDate(task.createdAt)}</div>
+        <div className="dagdo-panel-hint dagdo-panel-id">{task.id}</div>
+      </div>
+
+      <div className="dagdo-panel-footer">
+        <button className="dagdo-panel-delete" onClick={onDelete}>
+          Delete task
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}

--- a/web/src/TaskNode.tsx
+++ b/web/src/TaskNode.tsx
@@ -47,6 +47,11 @@ function TaskNodeImpl(props: NodeProps) {
           if (state !== "done") setEditing(true);
         }}
       >
+        <span
+          className={`dagdo-node-pri dagdo-node-pri-${task.priority}`}
+          title={`priority: ${task.priority}`}
+          aria-label={`priority ${task.priority}`}
+        />
         {editing ? (
           <input
             ref={inputRef}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { Task } from "./types";
+import type { Priority, Task } from "./types";
 
 /**
  * Thin fetch wrapper — matches the server routes in src/server/server.ts.
@@ -56,7 +56,14 @@ export async function createTask(args: { title: string }): Promise<Task> {
   return body.task;
 }
 
-export async function updateTask(id: string, patch: { title?: string }): Promise<Task> {
+export interface TaskPatch {
+  title?: string;
+  priority?: Priority;
+  tags?: string[];
+  doneAt?: string | null;
+}
+
+export async function updateTask(id: string, patch: TaskPatch): Promise<Task> {
   const res = await fetch(`/api/tasks/${id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8,6 +8,9 @@
   --ready: #c96442;
   --ready-fg: #faf9f5;
   --ready-border: #b5573a;
+  --pri-high: #c96442;
+  --pri-med: #87867f;
+  --pri-low: #c0bdb1;
 }
 
 * {
@@ -29,6 +32,13 @@ body,
   display: flex;
   flex-direction: column;
   height: 100vh;
+}
+
+.dagdo-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
 }
 
 .dagdo-header {
@@ -115,8 +125,10 @@ body,
   min-height: 0;
 }
 
-/* React Flow custom node styling */
+/* ─── node ─────────────────────────────────────────────────────────── */
+
 .dagdo-node-body {
+  position: relative;
   padding: 10px 14px;
   border-radius: 6px;
   font-family: Georgia, serif;
@@ -185,6 +197,42 @@ body,
   color: var(--text);
 }
 
+/* Priority indicator dot in the top-left corner of the node */
+.dagdo-node-pri {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--pri-med);
+}
+
+.dagdo-node-pri-high {
+  background: var(--pri-high);
+}
+
+.dagdo-node-pri-low {
+  background: var(--pri-low);
+}
+
+/* On terracotta (ready) nodes the high-priority dot blends in; inverted to stay
+ * visible without screaming. */
+.dagdo-node-ready .dagdo-node-pri-high {
+  background: var(--ready-fg);
+  opacity: 0.95;
+}
+
+.dagdo-node-ready .dagdo-node-pri-med {
+  background: var(--ready-fg);
+  opacity: 0.55;
+}
+
+.dagdo-node-ready .dagdo-node-pri-low {
+  background: var(--ready-fg);
+  opacity: 0.3;
+}
+
 /* Make React Flow handles a bit more visible/clickable */
 .react-flow__handle {
   width: 8px;
@@ -195,4 +243,218 @@ body,
 
 .react-flow__handle:hover {
   background: var(--ready);
+}
+
+/* ─── property panel ───────────────────────────────────────────────── */
+
+.dagdo-panel {
+  width: 280px;
+  min-width: 280px;
+  max-width: 280px;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  font-size: 13px;
+}
+
+.dagdo-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dagdo-panel-title {
+  font-weight: bold;
+  letter-spacing: 0.4px;
+}
+
+.dagdo-panel-close {
+  background: transparent;
+  border: none;
+  font-size: 14px;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.dagdo-panel-close:hover {
+  background: var(--bg);
+  color: var(--text);
+}
+
+.dagdo-panel-row {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dagdo-panel-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--muted);
+}
+
+.dagdo-panel-value {
+  color: var(--text);
+}
+
+.dagdo-panel-title-readonly {
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.dagdo-panel-hint {
+  font-size: 11px;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.dagdo-panel-id {
+  font-family: "SF Mono", Menlo, monospace;
+  font-style: normal;
+}
+
+.dagdo-panel-created {
+  font-size: 12px;
+}
+
+.dagdo-panel-segmented {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.dagdo-panel-seg {
+  flex: 1;
+  font-family: Georgia, serif;
+  font-size: 12px;
+  background: var(--surface);
+  color: var(--text);
+  border: none;
+  border-right: 1px solid var(--border);
+  padding: 6px 0;
+  cursor: pointer;
+  text-transform: capitalize;
+}
+
+.dagdo-panel-seg:last-child {
+  border-right: none;
+}
+
+.dagdo-panel-seg.is-active {
+  background: var(--ready);
+  color: var(--ready-fg);
+}
+
+.dagdo-panel-seg-high::before {
+  content: "● ";
+  color: var(--pri-high);
+}
+.dagdo-panel-seg-med::before {
+  content: "● ";
+  color: var(--pri-med);
+}
+.dagdo-panel-seg-low::before {
+  content: "● ";
+  color: var(--pri-low);
+}
+.dagdo-panel-seg.is-active::before {
+  color: var(--ready-fg);
+}
+
+.dagdo-panel-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dagdo-panel-empty {
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.dagdo-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 2px 4px 2px 10px;
+  font-size: 12px;
+}
+
+.dagdo-chip-remove {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.dagdo-chip-remove:hover {
+  color: var(--ready);
+}
+
+.dagdo-panel-input {
+  font-family: Georgia, serif;
+  font-size: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 5px 8px;
+  outline: none;
+}
+
+.dagdo-panel-input:focus {
+  border-color: var(--ready-border);
+  background: var(--surface);
+}
+
+.dagdo-panel-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.dagdo-panel-checkbox input {
+  cursor: pointer;
+  width: 14px;
+  height: 14px;
+}
+
+.dagdo-panel-footer {
+  margin-top: auto;
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+}
+
+.dagdo-panel-delete {
+  width: 100%;
+  font-family: Georgia, serif;
+  font-size: 12px;
+  background: var(--surface);
+  color: #8b3b23;
+  border: 1px solid #e4c9bd;
+  border-radius: 4px;
+  padding: 7px;
+  cursor: pointer;
+}
+
+.dagdo-panel-delete:hover {
+  background: #fdf0ec;
 }


### PR DESCRIPTION
Final stage of #8. Closes the issue.

## What is new
- Right-side property panel: click a node to open. Priority (high/med/low segmented control), tag chips with delete, add-tag input (Enter/comma/blur commit), Mark as done checkbox, created-at display, task ID, Delete button.
- Priority dot on every node (top-left), high/med/low colors. Inverts on terracotta (ready) nodes.

## Wiring
- updateTask widened to TaskPatch; server already supports priority/tags/doneAt from Stage 2.
- App.tsx tracks selectedId via React Flow onNodeClick / onPaneClick; selection auto-clears if task removed elsewhere.

## Test plan
- typecheck (root + web) clean
- 61 pass / 0 fail
- chrome-devtools: click node opens panel; priority change, tag add, mark done all reflect on disk and re-render node styling

Generated with Claude Code