### PR TITLE
Add dark-mode hero and <picture> toggle in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 *.png
 *.svg
 !docs/hero.svg
+!docs/hero-dark.svg
 
 # code coverage
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add dark-mode hero (`docs/hero-dark.svg`) and wire the README via a `<picture>` element with `prefers-color-scheme`, so the graph no longer looks like a bright slab on GitHub's dark theme. Regenerate both via `bun run scripts/gen-hero.ts [dark]`.
+
 ## [0.10.2] - 2026-04-21
 
 - Redraw README hero graph in the Linear palette with a richer 10-task topology (2 done roots → 2 ready → 4 blocked → integration hub → release), replacing the 4-task Slate-themed placeholder. Regenerate via `bun run scripts/gen-hero.ts > docs/hero.svg`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Dependency-aware todo manager. Tasks form a DAG (directed acyclic graph) — topological sort tells you what to do next.
 
-![dagdo graph](docs/hero.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/hero-dark.svg">
+  <img alt="dagdo graph" src="docs/hero.svg">
+</picture>
 
 Most todo apps treat tasks as a flat list. Real work has dependencies: you can't deploy before tests pass, can't test before the API is built. **dagdo** models your tasks as a graph and always tells you which tasks are ready to work on right now (zero in-degree nodes).
 

--- a/docs/hero-dark.svg
+++ b/docs/hero-dark.svg
@@ -1,0 +1,117 @@
+<svg width="860" height="640" viewBox="0 0 860 640"
+  xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+    <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#000000" flood-opacity="0.3"/>
+  </filter>
+  <filter id="shadow-elevated" x="-30%" y="-30%" width="160%" height="160%">
+    <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#5e6ad2" flood-opacity="0.4"/>
+  </filter>
+  <marker id="ah" markerWidth="9" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0,8 3,0 6" fill="#8a8f98"/>
+  </marker>
+  <marker id="ah-done" markerWidth="9" markerHeight="6" refX="7" refY="3" orient="auto">
+    <polygon points="0 0,8 3,0 6" fill="#3a3a40"/>
+  </marker>
+</defs>
+
+<rect width="860" height="640" fill="#0e0e10"/>
+
+<!-- ── Edges ── -->
+<line x1="230" y1="92" x2="230" y2="162"
+    stroke="#3a3a40" stroke-width="1.25" stroke-dasharray="4 3" marker-end="url(#ah-done)"/>
+<line x1="630" y1="92" x2="235.89454671020854" y2="166.88003612506037"
+    stroke="#3a3a40" stroke-width="1.25" stroke-dasharray="4 3" marker-end="url(#ah-done)"/>
+<line x1="630" y1="92" x2="630" y2="162"
+    stroke="#3a3a40" stroke-width="1.25" stroke-dasharray="4 3" marker-end="url(#ah-done)"/>
+<line x1="230" y1="220" x2="134.77697316473862" y2="292.36950039479865"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="230" y1="220" x2="325.2230268352614" y2="292.36950039479865"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="630" y1="220" x2="534.7769731647386" y2="292.36950039479865"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="630" y1="220" x2="725.2230268352614" y2="292.36950039479865"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="130" y1="348" x2="324.39129851646993" y2="421.8686934362586"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="330" y1="348" x2="330" y2="418"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="530" y1="348" x2="335.60870148353007" y2="421.8686934362586"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="730" y1="348" x2="534.2004284655563" y2="547.7155629651326"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+<line x1="330" y1="476" x2="524.3912985164699" y2="549.8686934362586"
+    stroke="#8a8f98" stroke-width="1.25"  marker-end="url(#ah)"/>
+
+<!-- ── Nodes ── -->
+<rect x="150" y="40" width="160" height="52" rx="8"
+    fill="#1c1c20" stroke="#2a2a30" stroke-width="1" stroke-dasharray="4 3"
+    />
+  <text x="230" y="63" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#6c6f77">✓  Research</text>
+  <text x="230" y="80" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#6c6f77">research · done</text>
+<rect x="550" y="40" width="160" height="52" rx="8"
+    fill="#1c1c20" stroke="#2a2a30" stroke-width="1" stroke-dasharray="4 3"
+    />
+  <text x="630" y="63" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#6c6f77">✓  Write PRD</text>
+  <text x="630" y="80" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#6c6f77">product · done</text>
+<rect x="150" y="168" width="160" height="52" rx="8"
+    fill="#5e6ad2" stroke="#5e6ad2" stroke-width="1" 
+    filter="url(#shadow-elevated)"/><circle cx="162" cy="180" r="3.5" fill="#ffffff"/>
+  <text x="230" y="191" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#ffffff">API contract</text>
+  <text x="230" y="208" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="rgba(255,255,255,0.78)">backend · high</text>
+<rect x="550" y="168" width="160" height="52" rx="8"
+    fill="#5e6ad2" stroke="#5e6ad2" stroke-width="1" 
+    filter="url(#shadow-elevated)"/><circle cx="562" cy="180" r="3.5" fill="#ffffff" opacity="0.65"/>
+  <text x="630" y="191" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#ffffff">UX mockups</text>
+  <text x="630" y="208" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="rgba(255,255,255,0.78)">design · medium</text>
+<rect x="50" y="296" width="160" height="52" rx="8"
+    fill="#1a1a1e" stroke="rgba(255,255,255,0.08)" stroke-width="1" 
+    filter="url(#shadow)"/><circle cx="62" cy="308" r="3.5" fill="#ff6368"/>
+  <text x="130" y="319" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#eeeeee">DB schema</text>
+  <text x="130" y="336" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#8a8f98">backend · high</text>
+<rect x="250" y="296" width="160" height="52" rx="8"
+    fill="#1a1a1e" stroke="rgba(255,255,255,0.08)" stroke-width="1" 
+    filter="url(#shadow)"/><circle cx="262" cy="308" r="3.5" fill="#ff6368"/>
+  <text x="330" y="319" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#eeeeee">Auth service</text>
+  <text x="330" y="336" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#8a8f98">backend · high</text>
+<rect x="450" y="296" width="160" height="52" rx="8"
+    fill="#1a1a1e" stroke="rgba(255,255,255,0.08)" stroke-width="1" 
+    filter="url(#shadow)"/><circle cx="462" cy="308" r="3.5" fill="#8a8f98"/>
+  <text x="530" y="319" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#eeeeee">UI kit</text>
+  <text x="530" y="336" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#8a8f98">frontend · medium</text>
+<rect x="650" y="296" width="160" height="52" rx="8"
+    fill="#1a1a1e" stroke="rgba(255,255,255,0.08)" stroke-width="1" 
+    filter="url(#shadow)"/><circle cx="662" cy="308" r="3.5" fill="#55595f"/>
+  <text x="730" y="319" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#eeeeee">Docs</text>
+  <text x="730" y="336" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#8a8f98">docs · low</text>
+<rect x="250" y="424" width="160" height="52" rx="8"
+    fill="#1a1a1e" stroke="rgba(255,255,255,0.08)" stroke-width="1" 
+    filter="url(#shadow)"/><circle cx="262" cy="436" r="3.5" fill="#ff6368"/>
+  <text x="330" y="447" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#eeeeee">Integration</text>
+  <text x="330" y="464" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#8a8f98">full-stack · high</text>
+<rect x="450" y="552" width="160" height="52" rx="8"
+    fill="#1a1a1e" stroke="rgba(255,255,255,0.08)" stroke-width="1" 
+    filter="url(#shadow)"/><circle cx="462" cy="564" r="3.5" fill="#ff6368"/>
+  <text x="530" y="575" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="13.5" font-weight="500" fill="#eeeeee">Release</text>
+  <text x="530" y="592" text-anchor="middle"
+    font-family="system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#8a8f98">ops · high</text>
+</svg>

--- a/scripts/gen-hero.ts
+++ b/scripts/gen-hero.ts
@@ -1,4 +1,9 @@
-// Run with: bun run scripts/gen-hero.ts > docs/hero.svg
+// Generate the README hero graph in a given theme.
+//
+//   bun run scripts/gen-hero.ts       > docs/hero.svg        # light (default)
+//   bun run scripts/gen-hero.ts dark  > docs/hero-dark.svg   # dark
+//
+// README uses <picture> with prefers-color-scheme to swap between them.
 
 const W = 860;
 const H = 640;
@@ -6,8 +11,35 @@ const NW = 160;
 const NH = 52;
 const R = 8;
 
+type Theme = "light" | "dark";
+
+interface Palette {
+  bg: string;
+  doneFill: string;
+  doneStroke: string;
+  doneText: string;
+  blockedFill: string;
+  blockedStroke: string;
+  blockedText: string;
+  blockedMeta: string;
+  readyFill: string;
+  readyText: string;
+  readyMeta: string;
+  priHigh: string;
+  priMed: string;
+  priLow: string;
+  edgeLive: string;
+  edgeDone: string;
+  /** Flood colour for the blocked-card drop shadow. */
+  shadowColor: string;
+  shadowOpacity: number;
+  /** Flood colour for the ready-node glow. */
+  elevatedGlow: string;
+  elevatedGlowOpacity: number;
+}
+
 // Linear-inspired light palette (mirrors web/src/styles.css).
-const C = {
+const LIGHT: Palette = {
   bg: "#f7f8f8",
   doneFill: "#f3f4f5",
   doneStroke: "#d0d6e0",
@@ -24,7 +56,39 @@ const C = {
   priLow: "#8a8f98",
   edgeLive: "#62666d",
   edgeDone: "#d0d6e0",
+  shadowColor: "#000000",
+  shadowOpacity: 0.05,
+  elevatedGlow: "#5e6ad2",
+  elevatedGlowOpacity: 0.22,
 };
+
+// Dark palette inspired by Linear's own dark theme: near-black page, lifted
+// surfaces, same indigo brand (it reads well on both backdrops).
+const DARK: Palette = {
+  bg: "#0e0e10",
+  doneFill: "#1c1c20",
+  doneStroke: "#2a2a30",
+  doneText: "#6c6f77",
+  blockedFill: "#1a1a1e",
+  blockedStroke: "rgba(255,255,255,0.08)",
+  blockedText: "#eeeeee",
+  blockedMeta: "#8a8f98",
+  readyFill: "#5e6ad2",
+  readyText: "#ffffff",
+  readyMeta: "rgba(255,255,255,0.78)",
+  priHigh: "#ff6368",
+  priMed: "#8a8f98",
+  priLow: "#55595f",
+  edgeLive: "#8a8f98",
+  edgeDone: "#3a3a40",
+  shadowColor: "#000000",
+  shadowOpacity: 0.3,
+  elevatedGlow: "#5e6ad2",
+  elevatedGlowOpacity: 0.4,
+};
+
+const theme: Theme = process.argv[2] === "dark" ? "dark" : "light";
+const C: Palette = theme === "dark" ? DARK : LIGHT;
 
 const FONT =
   "system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif";
@@ -177,10 +241,10 @@ const svg = `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}"
   xmlns="http://www.w3.org/2000/svg">
 <defs>
   <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-    <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="#000000" flood-opacity="0.05"/>
+    <feDropShadow dx="0" dy="1" stdDeviation="1.5" flood-color="${C.shadowColor}" flood-opacity="${C.shadowOpacity}"/>
   </filter>
   <filter id="shadow-elevated" x="-30%" y="-30%" width="160%" height="160%">
-    <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#5e6ad2" flood-opacity="0.22"/>
+    <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="${C.elevatedGlow}" flood-opacity="${C.elevatedGlowOpacity}"/>
   </filter>
   <marker id="ah" markerWidth="9" markerHeight="6" refX="7" refY="3" orient="auto">
     <polygon points="0 0,8 3,0 6" fill="${C.edgeLive}"/>


### PR DESCRIPTION
## Summary

- Parameterize `scripts/gen-hero.ts` with a theme argument and add a Linear-inspired dark palette (near-black bg, lifted dark cards, same indigo brand for ready nodes).
- Add `docs/hero-dark.svg` alongside the light version.
- Swap the README's bare `<img>` for a `<picture>` element with `prefers-color-scheme`, so readers with dark mode active (GitHub dark, OS dark, etc.) get the dark hero instead of a bright slab.

## Test plan

- [x] `bun run scripts/gen-hero.ts > docs/hero.svg` and `... dark > docs/hero-dark.svg` both render cleanly via `@resvg/resvg-js`
- [x] Spot-checked both PNG renders for contrast, text readability, edge visibility
- [ ] Verify README on GitHub in both light and dark themes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)