### PR TITLE
Enlarge connection handle hit area for easier edge drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- `dagdo ui` now has a 20×20 hit area around each node connection handle (visible dot still 8×8), making it much easier to start a manual edge drag — especially on trackpads and high-DPI displays. Adjacent-rank zones stay well clear with dagre's 70px ranksep, and the node body's double-click-to-edit remains reliable. (#19)
+
 ## [0.10.3] - 2026-04-21
 
 - Add dark-mode hero (`docs/hero-dark.svg`) and wire the README via a `<picture>` element with `prefers-color-scheme`, so the graph no longer looks like a bright slab on GitHub's dark theme. Regenerate both via `bun run scripts/gen-hero.ts [dark]`.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -282,12 +282,38 @@ body,
   opacity: 0.4;
 }
 
-/* React Flow handles */
+/* React Flow handles
+ *
+ * The visible dot stays 8×8, but we enlarge the pointer-event target to 20×20
+ * via a transparent ::before overlay. This makes it much easier to start an
+ * edge drag — especially on trackpads / high-DPI — without making the UI feel
+ * heavier. The overlay is centered on the handle (React Flow already
+ * translate(-50%, -50%)s the handle onto the node edge), so it extends 10px
+ * in every direction. With dagre ranksep=70, adjacent-rank hit zones stay
+ * well clear of each other (≥50px of gap between them), and with node padding
+ * of 12px the zone only reaches into the node body's inner padding — click /
+ * double-click on the node body itself remain reliable. */
 .react-flow__handle {
   width: 8px;
   height: 8px;
   background: var(--subtle);
   border: 1px solid var(--surface);
+}
+
+.react-flow__handle::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  transform: translate(-50%, -50%);
+  background: transparent;
+  /* Pseudo-element is transparent, so it doesn't occlude the visible dot.
+   * Events on this overlay bubble as if they originated on the parent
+   * .react-flow__handle, which is what React Flow's connection handler
+   * listens on — so drag begins exactly as it would on the dot itself. */
+  pointer-events: auto;
 }
 
 .react-flow__handle:hover {


### PR DESCRIPTION
## Summary

- Wrap each `.react-flow__handle` in a 20×20 transparent hit area via a `::before` overlay; the visible 8×8 dot is unchanged. Manual edge drags now begin anywhere inside the enlarged zone, which is especially forgiving on trackpads and high-DPI displays.
- No TS changes — CSS-only. Adjacent ranks stay well clear of each other (dagre's 70px ranksep) and the node body's double-click-to-edit target remains reliable.

Closes #19.

## Test plan

- [ ] Drag from a node's bottom handle to another's top handle starting from the outer edge of the new hit zone → edge creates as expected
- [ ] Hover indigo still lights up when hovering anywhere in the 20×20 zone (Chromium / Firefox / Safari)
- [ ] Short chains (tightly packed nodes) do not cross-hijack handles
- [ ] Double-click-to-edit on node body still works near top/bottom edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)