### PR TITLE
Add canvas popover editor and Space/Option shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- `dagdo ui` replaces the sidebar property panel with a compact popover anchored next to the selected node — less mouse travel for quick edits, stays glued to the node as you pan/zoom, flips from below-node to above when it would overflow the viewport, and dismisses on Esc or by clicking elsewhere. The popover now also lets you rename the task inline (the node's double-click rename still works). (#18)
+- `dagdo ui` adds two canvas shortcuts borrowed from Figma/Sketch: hold Space + left-drag to pan the canvas (grab cursor while held, resets cleanly on blur), and Cmd (macOS) / Ctrl (other platforms) + click on empty canvas to create a new task exactly at the cursor. Holding the modifier previews a dashed ghost where the new node will land; the click drops a draft node at that spot with its title input focused — type, press Enter to commit (Esc to cancel). No more `window.prompt`. (#21)
+
 ## [0.11.2] - 2026-04-21
 
 - Alpha publish workflow now leaves a sticky comment on the associated PR with the `npm i -g @coiggahou2002/dagdo@<version>` command for the just-published alpha. The comment updates in place on every subsequent push, so reviewers can install and smoke-test a branch without hunting through run logs for the version string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - `dagdo ui` replaces the sidebar property panel with a compact popover anchored next to the selected node — less mouse travel for quick edits, stays glued to the node as you pan/zoom, flips from below-node to above when it would overflow the viewport, and dismisses on Esc or by clicking elsewhere. The popover now also lets you rename the task inline (the node's double-click rename still works). (#18)
-- `dagdo ui` adds two canvas shortcuts borrowed from Figma/Sketch: hold Space + left-drag to pan the canvas (grab cursor while held, resets cleanly on blur), and Cmd (macOS) / Ctrl (other platforms) + click on empty canvas to create a new task exactly at the cursor. Holding the modifier previews a dashed ghost where the new node will land; the click drops a draft node at that spot with its title input focused — type, press Enter to commit (Esc to cancel). No more `window.prompt`. (#21)
+- `dagdo ui` adds two canvas shortcuts borrowed from Figma/Sketch: hold Space + left-drag to pan the canvas (grab cursor while held, resets cleanly on blur), and Option (macOS) / Alt (other platforms) + click on empty canvas to create a new task exactly at the cursor. Holding the modifier previews a dashed ghost where the new node will land; the click drops a draft node at that spot with its title input focused — type, press Enter to commit (Esc to cancel). No more `window.prompt`. Chose Option/Alt (not Cmd/Ctrl) so the shortcut doesn't clash with Cmd/Ctrl + scroll-to-zoom on the canvas. (#21)
 
 ## [0.11.2] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Tasks are stored in `~/.dagdo/data.json` — one user-level todo list across all
 **Canvas shortcuts:**
 
 - **Space + left-drag** — pan the canvas (grab cursor while held; borrowed from Figma/Sketch)
-- **Cmd + click** (macOS) / **Ctrl + click** (other platforms) on empty canvas — create a new task exactly at the click point
+- **Option + click** (macOS) / **Alt + click** (other platforms) on empty canvas — create a new task exactly at the click point
 - **Esc** — dismiss the popover
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ Tasks are stored in `~/.dagdo/data.json` — one user-level todo list across all
 
 ## Web view
 
-`dagdo ui` starts a local HTTP server on `http://localhost:3737`, opens your browser, and renders an interactive task graph. CLI changes from other terminals appear within a second; the browser can also edit: drag nodes to rearrange, drag from one node's bottom handle to another's top to create a dependency (with cycle detection), select a node/edge and press `Delete` to remove it, double-click a node title to rename it, and use the **+ New task** button in the header to add one. Click a node to open the property panel on the right — change priority, add/remove tags, or mark the task done.
+`dagdo ui` starts a local HTTP server on `http://localhost:3737`, opens your browser, and renders an interactive task graph. CLI changes from other terminals appear within a second; the browser can also edit: drag nodes to rearrange, drag from one node's bottom handle to another's top to create a dependency (with cycle detection), select a node/edge and press `Delete` to remove it, double-click a node title to rename it, and use the **+ New task** button in the header to add one. Click a node to open a compact popover anchored next to it — change priority, add/remove tags, or mark the task done.
+
+**Canvas shortcuts:**
+
+- **Space + left-drag** — pan the canvas (grab cursor while held; borrowed from Figma/Sketch)
+- **Cmd + click** (macOS) / **Ctrl + click** (other platforms) on empty canvas — create a new task exactly at the click point
+- **Esc** — dismiss the popover
 
 ```bash
 dagdo ui                  # default port 3737, opens a browser tab

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -465,10 +465,18 @@ export function App() {
       id: draftNodeId(draftId),
       type: "draft",
       position: draft.position,
-      // Non-interactive: users commit via Enter and cancel via Esc/blur, not
+      // Non-interactive: users commit via Enter and cancel via Esc, not
       // by dragging or selecting the placeholder.
       draggable: false,
       selectable: false,
+      // Pre-declare dimensions so React Flow skips the "render invisible,
+      // measure, then unhide" dance. Without this, the draft stays
+      // visibility:hidden forever: the measurement change lands in
+      // onNodesChange, but applyNodeChanges is running against `nodes`
+      // state (which does not contain the draft) and silently drops it,
+      // so the node is never un-hidden and its input can't receive focus
+      // or pointer events.
+      measured: { width: NODE_WIDTH, height: NODE_HEIGHT },
       data: {
         onCommit: (title: string) => void handleDraftCommit(draftId, draft.position, title),
         onCancel: () => handleDraftCancel(draftId),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import {
   type TaskPatch,
 } from "./api";
 import { TaskNode, type TaskNodeData } from "./TaskNode";
+import { DraftNode, type DraftNodeData } from "./DraftNode";
 import type { GraphData } from "./types";
 
 const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
@@ -33,7 +34,7 @@ const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
 type Status = "loading" | "connected" | "disconnected";
 type Toast = { kind: "error" | "info"; text: string } | null;
 
-const NODE_TYPES: NodeTypes = { task: TaskNode };
+const NODE_TYPES: NodeTypes = { task: TaskNode, draft: DraftNode };
 
 // macOS uses Cmd (metaKey) to mirror Figma/Sketch; every other platform uses Ctrl.
 // Detection runs once at module load — we deliberately don't react to changes.
@@ -49,6 +50,19 @@ function hasCreateModifier(event: { metaKey: boolean; ctrlKey: boolean }): boole
 // for future box-selection or other gestures.
 const PAN_BUTTONS_DEFAULT: number[] = [1, 2];
 const PAN_BUTTONS_SPACE: number[] = [0, 1, 2];
+
+// Node CSS nominal dimensions — kept in sync with `.dagdo-node-body` in styles.css.
+// Used to centre a new node on the click cursor (and match the preview ghost).
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 48;
+// Per-session id so React Flow unmounts the previous draft component (and its
+// local input state) when the user Cmd-clicks again at a new spot.
+const DRAFT_NODE_ID_PREFIX = "__dagdo_draft_";
+const draftNodeId = (seq: number): string => `${DRAFT_NODE_ID_PREFIX}${seq}`;
+const isDraftId = (id: string): boolean => id.startsWith(DRAFT_NODE_ID_PREFIX);
+
+type Draft = { id: number; position: { x: number; y: number } };
+type Ghost = { clientX: number; clientY: number };
 
 export function App() {
   const [graph, setGraph] = useState<GraphData>(EMPTY);
@@ -66,14 +80,27 @@ export function App() {
 
   // React Flow instance (captured via onInit). Needed for screenToFlowPosition
   // so Cmd/Ctrl+click can translate a viewport pixel coordinate back into the
-  // flow's world coordinate system, regardless of current pan/zoom.
-  const flowRef = useRef<ReactFlowInstance<FlowNode<TaskNodeData>, FlowEdge> | null>(null);
+  // flow's world coordinate system, regardless of current pan/zoom. The
+  // generic widens to the union because `<ReactFlow nodes={allNodes}>` infers
+  // its node type from the passed nodes, which include an optional draft.
+  const flowRef = useRef<ReactFlowInstance<FlowNode<TaskNodeData | DraftNodeData>, FlowEdge> | null>(null);
 
   // True while the user holds Space. Gated here rather than in CSS because
   // React Flow's `panOnDrag` prop needs the live value — CSS alone can't toggle
   // pan behavior. Reset on window blur so releasing Space outside the window
   // doesn't leave the canvas stuck in pan mode.
   const [isSpaceDown, setIsSpaceDown] = useState(false);
+
+  // Ghost preview shown under the cursor while the user holds the create
+  // modifier (Cmd/Ctrl) over the canvas. Stored as raw client coords so the
+  // overlay can render via `position: fixed` without recomputing on pan/zoom.
+  const [ghost, setGhost] = useState<Ghost | null>(null);
+
+  // In-flight "draft" node: a placeholder rendered at the click position with a
+  // focused input. Only one can exist at a time. `id` bumps on every new draft
+  // so a stale in-flight createTask never clobbers a newer draft.
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const draftSeq = useRef(0);
 
   // ─── data layer: fetch initial + subscribe to SSE ────────────────────
   useEffect(() => {
@@ -229,8 +256,11 @@ export function App() {
     }
   }, []);
 
-  const onNodesDelete = useCallback((deleted: FlowNode<TaskNodeData>[]) => {
+  const onNodesDelete = useCallback((deleted: FlowNode<TaskNodeData | DraftNodeData>[]) => {
     for (const node of deleted) {
+      // Draft nodes are non-selectable so this shouldn't fire for them, but
+      // guard — calling DELETE /api/tasks/__dagdo_draft_N would 404 noisily.
+      if (isDraftId(node.id)) continue;
       deleteTask(node.id).catch((err: unknown) => {
         showToast({ kind: "error", text: formatError("Delete failed", err) });
       });
@@ -239,6 +269,9 @@ export function App() {
 
   const onNodeClick = useCallback<NonNullable<React.ComponentProps<typeof ReactFlow>["onNodeClick"]>>(
     (_event, node) => {
+      // Clicks inside the draft node's input bubble up as node clicks — don't
+      // let them open a popover for a task that doesn't exist yet.
+      if (isDraftId(node.id)) return;
       setSelectedId(node.id);
     },
     [],
@@ -246,41 +279,77 @@ export function App() {
 
   const onPaneClick = useCallback(
     (event: React.MouseEvent) => {
-      // Cmd (macOS) / Ctrl (elsewhere) + click on empty pane creates a new
-      // task exactly at the click position. Plain click still clears selection.
+      // Cmd (macOS) / Ctrl (elsewhere) + click on empty pane drops a "draft"
+      // node at the click point. The node body auto-focuses its title input;
+      // Enter inside the draft commits, Esc/blur cancels. A second Cmd+click
+      // while a draft is already open replaces it with one at the new spot.
       if (hasCreateModifier(event)) {
         const flow = flowRef.current;
         if (!flow) return;
-        const position = flow.screenToFlowPosition({ x: event.clientX, y: event.clientY });
-        void createTaskAtPosition(position);
+        const flowPos = flow.screenToFlowPosition({ x: event.clientX, y: event.clientY });
+        // Centre the node on the cursor. At any zoom level, shifting the flow
+        // position by half the node's CSS size (in flow units) lands the node
+        // centred on the click — zoom drops out of the math because
+        // screenToFlowPosition has already accounted for it.
+        const position = {
+          x: flowPos.x - NODE_WIDTH / 2,
+          y: flowPos.y - NODE_HEIGHT / 2,
+        };
+        draftSeq.current += 1;
+        setDraft({ id: draftSeq.current, position });
+        // Hide the ghost: the draft's own box now represents the pending node.
+        setGhost(null);
         return;
       }
       setSelectedId(null);
     },
-    // createTaskAtPosition is defined below and is stable (useCallback)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
-  // Creates a task via the API and immediately pins its position to the click
-  // point (option 2 from the design doc — no backend schema change required).
-  // The node is marked `userPositioned` before the SSE broadcast arrives, so
-  // when the reconcile effect maps server state to Flow nodes it preserves the
-  // coordinate instead of handing the task to dagre.
-  const createTaskAtPosition = useCallback(
-    async (position: { x: number; y: number }) => {
-      const title = window.prompt("New task title:");
-      if (title == null) return;
-      const trimmed = title.trim();
-      if (trimmed.length === 0) return;
+  // onPaneMouseMove / onPaneMouseLeave drive the dashed ghost preview that
+  // appears under the cursor while the create-modifier is held. React Flow
+  // only fires these while the pointer is over the pane (empty canvas), so
+  // the ghost naturally hides when hovering nodes, handles, or controls.
+  const onPaneMouseMove = useCallback(
+    (event: React.MouseEvent) => {
+      if (hasCreateModifier(event)) {
+        setGhost({ clientX: event.clientX, clientY: event.clientY });
+      } else if (ghost !== null) {
+        setGhost(null);
+      }
+    },
+    [ghost],
+  );
+
+  const onPaneMouseLeave = useCallback(() => {
+    setGhost(null);
+  }, []);
+
+  // ─── draft task handlers ─────────────────────────────────────────────
+  const handleDraftCommit = useCallback(
+    async (draftId: number, position: { x: number; y: number }, title: string) => {
       try {
-        const task = await createTask({ title: trimmed });
+        const task = await createTask({ title });
         userPositioned.current.add(task.id);
-        // Seed the node locally so it renders at the click point even before
-        // the SSE broadcast arrives. The reconcile effect will merge it with
-        // server state and preserve this position (userPositioned is set).
+        // Seed / correct the local node at the draft's position. We tolerate
+        // an SSE broadcast that races ahead of the POST: if the reconcile
+        // effect already inserted the task at a dagre coord, update its
+        // position here; otherwise append it.
         setNodes((current) => {
-          if (current.some((n) => n.id === task.id)) return current;
+          const idx = current.findIndex((n) => n.id === task.id);
+          const nodeData = {
+            task,
+            state: "ready" as const,
+            onRename: handleRename,
+            onPatch: handlePatch,
+            onDelete: handleDelete,
+            onClosePopover: handleClosePopover,
+          };
+          if (idx >= 0) {
+            const next = [...current];
+            next[idx] = { ...next[idx], position, data: nodeData };
+            return next;
+          }
           return [
             ...current,
             {
@@ -289,27 +358,29 @@ export function App() {
               position,
               selected: false,
               draggable: true,
-              data: {
-                task,
-                state: "ready",
-                onRename: handleRename,
-                onPatch: handlePatch,
-                onDelete: handleDelete,
-                onClosePopover: handleClosePopover,
-              },
+              data: nodeData,
             },
           ];
         });
         showToast({ kind: "info", text: `Added "${task.title}"` });
       } catch (err) {
         showToast({ kind: "error", text: formatError("Add failed", err) });
+      } finally {
+        // Only clear the draft if the slot still belongs to this invocation —
+        // a second Cmd+click during the await creates a new draft we must not
+        // clobber.
+        setDraft((cur) => (cur && cur.id === draftId ? null : cur));
       }
     },
     [handleRename, handlePatch, handleDelete, handleClosePopover],
   );
 
+  const handleDraftCancel = useCallback((draftId: number) => {
+    setDraft((cur) => (cur && cur.id === draftId ? null : cur));
+  }, []);
+
   const onInit = useCallback(
-    (instance: ReactFlowInstance<FlowNode<TaskNodeData>, FlowEdge>) => {
+    (instance: ReactFlowInstance<FlowNode<TaskNodeData | DraftNodeData>, FlowEdge>) => {
       flowRef.current = instance;
     },
     [],
@@ -335,9 +406,14 @@ export function App() {
     }
     function onKeyUp(e: KeyboardEvent): void {
       if (e.code === "Space") setIsSpaceDown(false);
+      // Clear the ghost immediately on modifier release — onPaneMouseMove is
+      // only sampled on movement, so without this the ghost would linger until
+      // the next mousemove event.
+      if (!e.metaKey && !e.ctrlKey) setGhost(null);
     }
     function onBlur(): void {
       setIsSpaceDown(false);
+      setGhost(null);
     }
     window.addEventListener("keydown", onKeyDown);
     window.addEventListener("keyup", onKeyUp);
@@ -377,6 +453,29 @@ export function App() {
     const done = graph.tasks.filter((t) => t.doneAt != null).length;
     return { total: graph.tasks.length, done };
   }, [graph]);
+
+  // Merge the real nodes with an optional draft node. Kept as a derived value
+  // (rather than stuffing the draft into `nodes` state) so the reconcile
+  // effect stays a clean task↔node mapping and never accidentally persists
+  // the draft through a graph refresh.
+  const allNodes = useMemo<FlowNode<TaskNodeData | DraftNodeData>[]>(() => {
+    if (!draft) return nodes;
+    const draftId = draft.id;
+    const draftNode: FlowNode<DraftNodeData> = {
+      id: draftNodeId(draftId),
+      type: "draft",
+      position: draft.position,
+      // Non-interactive: users commit via Enter and cancel via Esc/blur, not
+      // by dragging or selecting the placeholder.
+      draggable: false,
+      selectable: false,
+      data: {
+        onCommit: (title: string) => void handleDraftCommit(draftId, draft.position, title),
+        onCancel: () => handleDraftCancel(draftId),
+      },
+    };
+    return [...nodes, draftNode];
+  }, [nodes, draft, handleDraftCommit, handleDraftCancel]);
 
   // Esc closes the popover. Bound at the window so the key works regardless of
   // whether focus is on the canvas or elsewhere; only active while a task is
@@ -422,7 +521,7 @@ export function App() {
         ) : (
           <div className={`dagdo-canvas${isSpaceDown ? " is-space-down" : ""}`}>
             <ReactFlow
-              nodes={nodes}
+              nodes={allNodes}
               edges={edges}
               nodeTypes={NODE_TYPES}
               onInit={onInit}
@@ -434,6 +533,8 @@ export function App() {
               onNodesDelete={onNodesDelete}
               onNodeClick={onNodeClick}
               onPaneClick={onPaneClick}
+              onPaneMouseMove={onPaneMouseMove}
+              onPaneMouseLeave={onPaneMouseLeave}
               panOnDrag={isSpaceDown ? PAN_BUTTONS_SPACE : PAN_BUTTONS_DEFAULT}
               fitView
               proOptions={{ hideAttribution: true }}
@@ -442,6 +543,14 @@ export function App() {
               <Controls showInteractive={false} />
               <MiniMap pannable zoomable maskColor="rgba(247, 248, 248, 0.7)" />
             </ReactFlow>
+            {ghost && !draft && (
+              // pointer-events: none in CSS — never blocks the click it previews.
+              <div
+                className="dagdo-create-ghost"
+                style={{ left: ghost.clientX, top: ghost.clientY }}
+                aria-hidden="true"
+              />
+            )}
           </div>
         )}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,13 +36,11 @@ type Toast = { kind: "error" | "info"; text: string } | null;
 
 const NODE_TYPES: NodeTypes = { task: TaskNode, draft: DraftNode };
 
-// macOS uses Cmd (metaKey) to mirror Figma/Sketch; every other platform uses Ctrl.
-// Detection runs once at module load — we deliberately don't react to changes.
-const IS_MAC =
-  typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
-
-function hasCreateModifier(event: { metaKey: boolean; ctrlKey: boolean }): boolean {
-  return IS_MAC ? event.metaKey : event.ctrlKey;
+// Option (macOS) / Alt (everywhere else) — same `altKey` on every platform, no
+// branching needed. Chosen over Cmd/Ctrl to stay out of the way of the
+// browser's Cmd/Ctrl + scroll-to-zoom gesture on the canvas.
+function hasCreateModifier(event: { altKey: boolean }): boolean {
+  return event.altKey;
 }
 
 // While Space is held: include left-mouse (button 0) so left-drag pans the
@@ -72,14 +70,14 @@ export function App() {
   const [edges, setEdges] = useState<FlowEdge[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  // IDs of nodes the user has manually dragged or placed via Cmd/Ctrl+click —
+  // IDs of nodes the user has manually dragged or placed via Option/Alt+click —
   // their positions should survive SSE-driven rebuilds rather than snapping back
   // to the dagre layout. Pristine nodes pick up fresh dagre coordinates each time
   // the topology changes.
   const userPositioned = useRef(new Set<string>());
 
   // React Flow instance (captured via onInit). Needed for screenToFlowPosition
-  // so Cmd/Ctrl+click can translate a viewport pixel coordinate back into the
+  // so Option/Alt+click can translate a viewport pixel coordinate back into the
   // flow's world coordinate system, regardless of current pan/zoom. The
   // generic widens to the union because `<ReactFlow nodes={allNodes}>` infers
   // its node type from the passed nodes, which include an optional draft.
@@ -279,7 +277,7 @@ export function App() {
 
   const onPaneClick = useCallback(
     (event: React.MouseEvent) => {
-      // Cmd (macOS) / Ctrl (elsewhere) + click on empty pane drops a "draft"
+      // Option (macOS) / Alt (elsewhere) + click on empty pane drops a "draft"
       // node at the click point. The node body auto-focuses its title input;
       // Enter inside the draft commits, Esc/blur cancels. A second Cmd+click
       // while a draft is already open replaces it with one at the new spot.
@@ -409,7 +407,7 @@ export function App() {
       // Clear the ghost immediately on modifier release — onPaneMouseMove is
       // only sampled on movement, so without this the ghost would linger until
       // the next mousemove event.
-      if (!e.metaKey && !e.ctrlKey) setGhost(null);
+      if (!e.altKey) setGhost(null);
     }
     function onBlur(): void {
       setIsSpaceDown(false);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import {
   type NodeChange,
   type EdgeChange,
   type NodeTypes,
+  type ReactFlowInstance,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { layoutGraph } from "./layout";
@@ -25,7 +26,6 @@ import {
   type TaskPatch,
 } from "./api";
 import { TaskNode, type TaskNodeData } from "./TaskNode";
-import { PropertyPanel } from "./PropertyPanel";
 import type { GraphData } from "./types";
 
 const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
@@ -35,6 +35,21 @@ type Toast = { kind: "error" | "info"; text: string } | null;
 
 const NODE_TYPES: NodeTypes = { task: TaskNode };
 
+// macOS uses Cmd (metaKey) to mirror Figma/Sketch; every other platform uses Ctrl.
+// Detection runs once at module load — we deliberately don't react to changes.
+const IS_MAC =
+  typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
+
+function hasCreateModifier(event: { metaKey: boolean; ctrlKey: boolean }): boolean {
+  return IS_MAC ? event.metaKey : event.ctrlKey;
+}
+
+// While Space is held: include left-mouse (button 0) so left-drag pans the
+// viewport. Default keeps middle/right only, leaving plain left-drag free
+// for future box-selection or other gestures.
+const PAN_BUTTONS_DEFAULT: number[] = [1, 2];
+const PAN_BUTTONS_SPACE: number[] = [0, 1, 2];
+
 export function App() {
   const [graph, setGraph] = useState<GraphData>(EMPTY);
   const [status, setStatus] = useState<Status>("loading");
@@ -43,10 +58,22 @@ export function App() {
   const [edges, setEdges] = useState<FlowEdge[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  // IDs of nodes the user has manually dragged — their positions should survive
-  // SSE-driven rebuilds rather than snapping back to the dagre layout. Pristine
-  // nodes pick up fresh dagre coordinates each time the topology changes.
+  // IDs of nodes the user has manually dragged or placed via Cmd/Ctrl+click —
+  // their positions should survive SSE-driven rebuilds rather than snapping back
+  // to the dagre layout. Pristine nodes pick up fresh dagre coordinates each time
+  // the topology changes.
   const userPositioned = useRef(new Set<string>());
+
+  // React Flow instance (captured via onInit). Needed for screenToFlowPosition
+  // so Cmd/Ctrl+click can translate a viewport pixel coordinate back into the
+  // flow's world coordinate system, regardless of current pan/zoom.
+  const flowRef = useRef<ReactFlowInstance<FlowNode<TaskNodeData>, FlowEdge> | null>(null);
+
+  // True while the user holds Space. Gated here rather than in CSS because
+  // React Flow's `panOnDrag` prop needs the live value — CSS alone can't toggle
+  // pan behavior. Reset on window blur so releasing Space outside the window
+  // doesn't leave the canvas stuck in pan mode.
+  const [isSpaceDown, setIsSpaceDown] = useState(false);
 
   // ─── data layer: fetch initial + subscribe to SSE ────────────────────
   useEffect(() => {
@@ -92,6 +119,17 @@ export function App() {
     });
   }, []);
 
+  const handleDelete = useCallback((id: string) => {
+    deleteTask(id).catch((err: unknown) => {
+      showToast({ kind: "error", text: formatError("Delete failed", err) });
+    });
+    setSelectedId((sel) => (sel === id ? null : sel));
+  }, []);
+
+  const handleClosePopover = useCallback(() => {
+    setSelectedId(null);
+  }, []);
+
   // ─── reconcile Flow state whenever server state changes ──────────────
   useEffect(() => {
     const autoLayout = layoutGraph(graph.tasks, graph.edges);
@@ -116,6 +154,9 @@ export function App() {
             task,
             state: auto?.state ?? "blocked",
             onRename: handleRename,
+            onPatch: handlePatch,
+            onDelete: handleDelete,
+            onClosePopover: handleClosePopover,
           },
           // Draggable always; deletable via backspace/delete.
           draggable: true,
@@ -129,7 +170,7 @@ export function App() {
       if (!aliveIds.has(id)) userPositioned.current.delete(id);
     }
     // If the selected task was removed elsewhere, drop the selection so the
-    // panel closes rather than lingering on stale data.
+    // popover closes rather than lingering on stale data.
     if (selectedId && !aliveIds.has(selectedId)) {
       setSelectedId(null);
     }
@@ -149,7 +190,7 @@ export function App() {
         };
       }),
     );
-  }, [graph, handleRename, selectedId]);
+  }, [graph, handleRename, handlePatch, handleDelete, handleClosePopover, selectedId]);
 
   // ─── React Flow event handlers ───────────────────────────────────────
   const onNodesChange = useCallback((changes: NodeChange[]) => {
@@ -203,8 +244,109 @@ export function App() {
     [],
   );
 
-  const onPaneClick = useCallback(() => {
-    setSelectedId(null);
+  const onPaneClick = useCallback(
+    (event: React.MouseEvent) => {
+      // Cmd (macOS) / Ctrl (elsewhere) + click on empty pane creates a new
+      // task exactly at the click position. Plain click still clears selection.
+      if (hasCreateModifier(event)) {
+        const flow = flowRef.current;
+        if (!flow) return;
+        const position = flow.screenToFlowPosition({ x: event.clientX, y: event.clientY });
+        void createTaskAtPosition(position);
+        return;
+      }
+      setSelectedId(null);
+    },
+    // createTaskAtPosition is defined below and is stable (useCallback)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  // Creates a task via the API and immediately pins its position to the click
+  // point (option 2 from the design doc — no backend schema change required).
+  // The node is marked `userPositioned` before the SSE broadcast arrives, so
+  // when the reconcile effect maps server state to Flow nodes it preserves the
+  // coordinate instead of handing the task to dagre.
+  const createTaskAtPosition = useCallback(
+    async (position: { x: number; y: number }) => {
+      const title = window.prompt("New task title:");
+      if (title == null) return;
+      const trimmed = title.trim();
+      if (trimmed.length === 0) return;
+      try {
+        const task = await createTask({ title: trimmed });
+        userPositioned.current.add(task.id);
+        // Seed the node locally so it renders at the click point even before
+        // the SSE broadcast arrives. The reconcile effect will merge it with
+        // server state and preserve this position (userPositioned is set).
+        setNodes((current) => {
+          if (current.some((n) => n.id === task.id)) return current;
+          return [
+            ...current,
+            {
+              id: task.id,
+              type: "task",
+              position,
+              selected: false,
+              draggable: true,
+              data: {
+                task,
+                state: "ready",
+                onRename: handleRename,
+                onPatch: handlePatch,
+                onDelete: handleDelete,
+                onClosePopover: handleClosePopover,
+              },
+            },
+          ];
+        });
+        showToast({ kind: "info", text: `Added "${task.title}"` });
+      } catch (err) {
+        showToast({ kind: "error", text: formatError("Add failed", err) });
+      }
+    },
+    [handleRename, handlePatch, handleDelete, handleClosePopover],
+  );
+
+  const onInit = useCallback(
+    (instance: ReactFlowInstance<FlowNode<TaskNodeData>, FlowEdge>) => {
+      flowRef.current = instance;
+    },
+    [],
+  );
+
+  // Space-held pan mode. Key listeners live on window so the shortcut works
+  // even when focus is on a nested element. We also reset on blur to avoid a
+  // "stuck in pan mode" state if the user releases Space outside the window.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.code !== "Space") return;
+      // If the user is typing in an input (task title, tag editor, etc.), don't
+      // hijack Space. contentEditable covers the rename input and any future
+      // rich-text fields.
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) return;
+      }
+      // Prevent the default page-scroll that Space triggers on some browsers.
+      e.preventDefault();
+      setIsSpaceDown(true);
+    }
+    function onKeyUp(e: KeyboardEvent): void {
+      if (e.code === "Space") setIsSpaceDown(false);
+    }
+    function onBlur(): void {
+      setIsSpaceDown(false);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+    };
   }, []);
 
   // ─── "add task" button ───────────────────────────────────────────────
@@ -236,10 +378,17 @@ export function App() {
     return { total: graph.tasks.length, done };
   }, [graph]);
 
-  const selectedTask = useMemo(
-    () => (selectedId ? graph.tasks.find((t) => t.id === selectedId) ?? null : null),
-    [selectedId, graph.tasks],
-  );
+  // Esc closes the popover. Bound at the window so the key works regardless of
+  // whether focus is on the canvas or elsewhere; only active while a task is
+  // selected to avoid interfering with other keyboard handling.
+  useEffect(() => {
+    if (!selectedId) return;
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === "Escape") setSelectedId(null);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedId]);
 
   return (
     <div className="dagdo-root">
@@ -271,11 +420,12 @@ export function App() {
             </button>
           </div>
         ) : (
-          <div className="dagdo-canvas">
+          <div className={`dagdo-canvas${isSpaceDown ? " is-space-down" : ""}`}>
             <ReactFlow
               nodes={nodes}
               edges={edges}
               nodeTypes={NODE_TYPES}
+              onInit={onInit}
               onNodesChange={onNodesChange}
               onEdgesChange={onEdgesChange}
               onNodeDragStop={onNodeDragStop}
@@ -284,6 +434,7 @@ export function App() {
               onNodesDelete={onNodesDelete}
               onNodeClick={onNodeClick}
               onPaneClick={onPaneClick}
+              panOnDrag={isSpaceDown ? PAN_BUTTONS_SPACE : PAN_BUTTONS_DEFAULT}
               fitView
               proOptions={{ hideAttribution: true }}
             >
@@ -294,19 +445,6 @@ export function App() {
           </div>
         )}
 
-        {selectedTask && (
-          <PropertyPanel
-            task={selectedTask}
-            onChange={(patch) => handlePatch(selectedTask.id, patch)}
-            onDelete={() => {
-              deleteTask(selectedTask.id).catch((err: unknown) => {
-                showToast({ kind: "error", text: formatError("Delete failed", err) });
-              });
-              setSelectedId(null);
-            }}
-            onClose={() => setSelectedId(null)}
-          />
-        )}
       </div>
     </div>
   );

--- a/web/src/DraftNode.tsx
+++ b/web/src/DraftNode.tsx
@@ -7,7 +7,7 @@ export interface DraftNodeData extends Record<string, unknown> {
 }
 
 /**
- * Placeholder node rendered at a Cmd/Ctrl+click point. Auto-focuses its title
+ * Placeholder node rendered at an Option/Alt+click point. Auto-focuses its title
  * input; Enter commits (creating the real task), Esc cancels. Clicking
  * elsewhere blurs the input but leaves the draft on-canvas — users can click
  * the input again to resume typing. Positioning and NODE_TYPES registration

--- a/web/src/DraftNode.tsx
+++ b/web/src/DraftNode.tsx
@@ -60,12 +60,12 @@ function DraftNodeImpl(props: NodeProps) {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleKeyDown}
-          // React Flow listens for Backspace/Delete at the canvas level to
-          // remove selected nodes — stop capture-phase listeners from seeing
-          // keys typed into the draft input.
-          onKeyDownCapture={(e) => e.stopPropagation()}
           // Belt: prevent the pane's mousedown handler from stealing focus
-          // on the click that focuses this input.
+          // on the click that focuses this input. React Flow's own
+          // `isInputDOMNode` check already suppresses its window-level
+          // keyboard shortcuts (Backspace/Delete) when an input is focused,
+          // so no capture-phase stopPropagation is needed — and it would
+          // actively break onKeyDown bubble handling on this element.
           onMouseDown={(e) => e.stopPropagation()}
         />
       </div>

--- a/web/src/DraftNode.tsx
+++ b/web/src/DraftNode.tsx
@@ -8,14 +8,19 @@ export interface DraftNodeData extends Record<string, unknown> {
 
 /**
  * Placeholder node rendered at a Cmd/Ctrl+click point. Auto-focuses its title
- * input; Enter commits (creating the real task), Esc or blur cancels.
- * Positioning and NODE_TYPES registration live in App.tsx.
+ * input; Enter commits (creating the real task), Esc cancels. Clicking
+ * elsewhere blurs the input but leaves the draft on-canvas — users can click
+ * the input again to resume typing. Positioning and NODE_TYPES registration
+ * live in App.tsx.
  */
 function DraftNodeImpl(props: NodeProps) {
   const { onCommit, onCancel } = props.data as DraftNodeData;
   const [title, setTitle] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Belt-and-braces focus: React's `autoFocus` prop fires during commit (early
+  // enough to beat pointer-event focus shuffles from the originating click),
+  // and this useEffect is the backup if something re-renders around us.
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -43,21 +48,25 @@ function DraftNodeImpl(props: NodeProps) {
           transition feels like the same object evolving, but they're not
           connectable — there is no task yet to link. */}
       <Handle type="target" position={Position.Top} isConnectable={false} />
-      <div className="dagdo-node-body dagdo-node-draft">
+      {/* `nodrag nopan` on the wrapper tells React Flow "hands off" for
+          pointer events — without them the library's internal drag/pan
+          handlers steal the click from the input and prevent focus. */}
+      <div className="dagdo-node-body dagdo-node-draft nodrag nopan">
         <input
           ref={inputRef}
-          className="dagdo-node-input"
+          autoFocus
+          className="dagdo-node-input nodrag nopan"
           placeholder="Task title…"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleKeyDown}
-          // React Flow eats Backspace/Delete at the canvas level to remove
-          // selected nodes — stop the capture-phase listener from seeing keys
-          // typed into the draft input.
+          // React Flow listens for Backspace/Delete at the canvas level to
+          // remove selected nodes — stop capture-phase listeners from seeing
+          // keys typed into the draft input.
           onKeyDownCapture={(e) => e.stopPropagation()}
-          // Blur = click-outside = cancel. Matches Linear/Notion's
-          // new-item-input convention: explicit Enter required to commit.
-          onBlur={onCancel}
+          // Belt: prevent the pane's mousedown handler from stealing focus
+          // on the click that focuses this input.
+          onMouseDown={(e) => e.stopPropagation()}
         />
       </div>
       <Handle type="source" position={Position.Bottom} isConnectable={false} />

--- a/web/src/DraftNode.tsx
+++ b/web/src/DraftNode.tsx
@@ -1,0 +1,68 @@
+import { memo, useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+
+export interface DraftNodeData extends Record<string, unknown> {
+  onCommit: (title: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Placeholder node rendered at a Cmd/Ctrl+click point. Auto-focuses its title
+ * input; Enter commits (creating the real task), Esc or blur cancels.
+ * Positioning and NODE_TYPES registration live in App.tsx.
+ */
+function DraftNodeImpl(props: NodeProps) {
+  const { onCommit, onCancel } = props.data as DraftNodeData;
+  const [title, setTitle] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function submit(): void {
+    const next = title.trim();
+    if (next.length === 0) onCancel();
+    else onCommit(next);
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onCancel();
+    }
+  }
+
+  return (
+    <>
+      {/* Handles mirror a real task node's layout so the ghost→draft→task
+          transition feels like the same object evolving, but they're not
+          connectable — there is no task yet to link. */}
+      <Handle type="target" position={Position.Top} isConnectable={false} />
+      <div className="dagdo-node-body dagdo-node-draft">
+        <input
+          ref={inputRef}
+          className="dagdo-node-input"
+          placeholder="Task title…"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          // React Flow eats Backspace/Delete at the canvas level to remove
+          // selected nodes — stop the capture-phase listener from seeing keys
+          // typed into the draft input.
+          onKeyDownCapture={(e) => e.stopPropagation()}
+          // Blur = click-outside = cancel. Matches Linear/Notion's
+          // new-item-input convention: explicit Enter required to commit.
+          onBlur={onCancel}
+        />
+      </div>
+      <Handle type="source" position={Position.Bottom} isConnectable={false} />
+    </>
+  );
+}
+
+export const DraftNode = memo(DraftNodeImpl);

--- a/web/src/TaskNode.tsx
+++ b/web/src/TaskNode.tsx
@@ -1,18 +1,41 @@
-import { memo, useEffect, useRef, useState } from "react";
-import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Handle,
+  NodeToolbar,
+  Position,
+  useViewport,
+  type NodeProps,
+} from "@xyflow/react";
 import type { NodeState, Task } from "./types";
+import { TaskPopover } from "./TaskPopover";
+import type { TaskPatch } from "./api";
 
 export interface TaskNodeData extends Record<string, unknown> {
   task: Task;
   state: NodeState;
   onRename: (id: string, title: string) => void;
+  onPatch: (id: string, patch: TaskPatch) => void;
+  onDelete: (id: string) => void;
+  onClosePopover: () => void;
 }
 
+const POPOVER_OFFSET = 10;
+/** How close the popover can get to a viewport edge before we flip it. */
+const VIEWPORT_MARGIN = 8;
+
 function TaskNodeImpl(props: NodeProps) {
-  const { task, state, onRename } = props.data as TaskNodeData;
+  const { task, state, onRename, onPatch, onDelete, onClosePopover } = props.data as TaskNodeData;
+  const selected = props.selected === true;
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.title);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Popover placement: prefer below the node; flip to above if the popover
+  // would overflow the viewport's bottom edge. Recomputed whenever the
+  // viewport changes (pan/zoom) or the popover opens.
+  const [popoverPosition, setPopoverPosition] = useState<Position>(Position.Bottom);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const viewport = useViewport();
 
   useEffect(() => {
     if (!editing) setDraft(task.title);
@@ -21,6 +44,51 @@ function TaskNodeImpl(props: NodeProps) {
   useEffect(() => {
     if (editing) inputRef.current?.select();
   }, [editing]);
+
+  // After the popover paints (or the viewport moves), check whether it fits
+  // where we placed it. If the currently-chosen edge overflows the viewport
+  // and the opposite edge has room, flip.
+  useLayoutEffect(() => {
+    if (!selected) return;
+    const el = popoverRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const winH = window.innerHeight;
+    const winW = window.innerWidth;
+
+    if (popoverPosition === Position.Bottom) {
+      if (rect.bottom > winH - VIEWPORT_MARGIN) {
+        // Only flip if there's actually more room above — otherwise stay put
+        // and let the popover scroll/clip rather than dance between sides.
+        const overflowBelow = rect.bottom - (winH - VIEWPORT_MARGIN);
+        const spaceAbove = rect.top - VIEWPORT_MARGIN; // current top, pre-flip
+        if (spaceAbove > overflowBelow) {
+          setPopoverPosition(Position.Top);
+        }
+      }
+    } else if (popoverPosition === Position.Top) {
+      if (rect.top < VIEWPORT_MARGIN) {
+        const overflowAbove = VIEWPORT_MARGIN - rect.top;
+        const spaceBelow = winH - VIEWPORT_MARGIN - rect.bottom;
+        if (spaceBelow > overflowAbove) {
+          setPopoverPosition(Position.Bottom);
+        }
+      }
+    }
+
+    // Horizontal overflow: NodeToolbar centers the popover over the node, so
+    // if the node is near a viewport edge the popover may still clip. There's
+    // no Position.Top-Left in the typed enum; we leave horizontal handling to
+    // the CSS max-width — the popover is only ~260px wide and the canvas is
+    // unlikely to scroll this into a dead corner in practice.
+    void winW;
+  }, [selected, popoverPosition, viewport.x, viewport.y, viewport.zoom, task.title, task.tags.length]);
+
+  // Reset to preferred side each time the popover opens on a (possibly new)
+  // node, so moving between nodes doesn't carry over a stale flip.
+  useEffect(() => {
+    if (selected) setPopoverPosition(Position.Bottom);
+  }, [selected, task.id]);
 
   function commit(): void {
     setEditing(false);
@@ -80,6 +148,23 @@ function TaskNodeImpl(props: NodeProps) {
         )}
       </div>
       <Handle type="source" position={Position.Bottom} />
+
+      <NodeToolbar
+        isVisible={selected && !editing}
+        position={popoverPosition}
+        offset={POPOVER_OFFSET}
+      >
+        {/* NodeToolbar's typed props don't expose ref; wrap in a plain div so
+            the flip-logic effect can measure the popover's rendered rect. */}
+        <div ref={popoverRef}>
+          <TaskPopover
+            task={task}
+            onChange={(patch) => onPatch(task.id, patch)}
+            onDelete={() => onDelete(task.id)}
+            onClose={onClosePopover}
+          />
+        </div>
+      </NodeToolbar>
     </>
   );
 }

--- a/web/src/TaskPopover.tsx
+++ b/web/src/TaskPopover.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState, type KeyboardEvent } from "react";
+import { useEffect, useState, type KeyboardEvent, type MouseEvent } from "react";
 import type { Priority, Task } from "./types";
 
-interface PropertyPanelProps {
+interface TaskPopoverProps {
   task: Task;
   onChange: (patch: { priority?: Priority; tags?: string[]; doneAt?: string | null }) => void;
   onDelete: () => void;
@@ -10,7 +10,12 @@ interface PropertyPanelProps {
 
 const PRIORITIES: Priority[] = ["high", "med", "low"];
 
-export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPanelProps) {
+/**
+ * Compact, in-canvas editor for a single task. Rendered inside a React Flow
+ * <NodeToolbar>, so positioning / zoom-tracking is handled upstream — this
+ * component is pure UI.
+ */
+export function TaskPopover({ task, onChange, onDelete, onClose }: TaskPopoverProps) {
   const [tagDraft, setTagDraft] = useState("");
 
   // Reset the tag draft when switching between tasks so input doesn't leak.
@@ -35,34 +40,45 @@ export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPan
       e.preventDefault();
       addTag(tagDraft);
     } else if (e.key === "Escape") {
-      setTagDraft("");
+      e.preventDefault();
+      // Let the wrapper's Esc-handler close the popover only if the draft is empty;
+      // otherwise consume Escape to clear the draft.
+      if (tagDraft.length > 0) {
+        e.stopPropagation();
+        setTagDraft("");
+      }
     }
   }
 
   const done = task.doneAt != null;
 
+  // Swallow pointer events so clicks inside the popover don't bubble up to the
+  // React Flow pane handler (which would close the popover via onPaneClick).
+  const stop = (e: MouseEvent) => e.stopPropagation();
+
   return (
-    <aside className="dagdo-panel">
-      <div className="dagdo-panel-head">
-        <span className="dagdo-panel-title">Task</span>
-        <button className="dagdo-panel-close" onClick={onClose} aria-label="Close panel">
+    <div
+      className="dagdo-popover"
+      role="dialog"
+      aria-label={`Edit task ${task.title}`}
+      onClick={stop}
+      onMouseDown={stop}
+      onPointerDown={stop}
+    >
+      <div className="dagdo-popover-head">
+        <span className="dagdo-popover-title">Task</span>
+        <button className="dagdo-popover-close" onClick={onClose} aria-label="Close">
           ✕
         </button>
       </div>
 
-      <div className="dagdo-panel-row">
-        <div className="dagdo-panel-label">Title</div>
-        <div className="dagdo-panel-value dagdo-panel-title-readonly">{task.title}</div>
-        <div className="dagdo-panel-hint">Double-click the node to rename.</div>
-      </div>
-
-      <div className="dagdo-panel-row">
-        <div className="dagdo-panel-label">Priority</div>
-        <div className="dagdo-panel-segmented">
+      <div className="dagdo-popover-row">
+        <div className="dagdo-popover-label">Priority</div>
+        <div className="dagdo-popover-segmented">
           {PRIORITIES.map((p) => (
             <button
               key={p}
-              className={`dagdo-panel-seg ${task.priority === p ? "is-active" : ""} dagdo-panel-seg-${p}`}
+              className={`dagdo-popover-seg ${task.priority === p ? "is-active" : ""} dagdo-popover-seg-${p}`}
               onClick={() => {
                 if (task.priority !== p) onChange({ priority: p });
               }}
@@ -73,9 +89,9 @@ export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPan
         </div>
       </div>
 
-      <div className="dagdo-panel-row">
-        <div className="dagdo-panel-label">Tags</div>
-        <div className="dagdo-panel-tags">
+      <div className="dagdo-popover-row">
+        <div className="dagdo-popover-label">Tags</div>
+        <div className="dagdo-popover-tags">
           {task.tags.map((tag) => (
             <span key={tag} className="dagdo-chip">
               {tag}
@@ -88,10 +104,10 @@ export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPan
               </button>
             </span>
           ))}
-          {task.tags.length === 0 && <span className="dagdo-panel-empty">no tags</span>}
+          {task.tags.length === 0 && <span className="dagdo-popover-empty">no tags</span>}
         </div>
         <input
-          className="dagdo-panel-input"
+          className="dagdo-popover-input"
           placeholder="add tag (Enter)"
           value={tagDraft}
           onChange={(e) => setTagDraft(e.target.value)}
@@ -100,8 +116,8 @@ export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPan
         />
       </div>
 
-      <div className="dagdo-panel-row">
-        <label className="dagdo-panel-checkbox">
+      <div className="dagdo-popover-row">
+        <label className="dagdo-popover-checkbox">
           <input
             type="checkbox"
             checked={done}
@@ -110,22 +126,19 @@ export function PropertyPanel({ task, onChange, onDelete, onClose }: PropertyPan
           <span>Mark as done</span>
         </label>
         {done && task.doneAt && (
-          <div className="dagdo-panel-hint">Completed {formatDate(task.doneAt)}</div>
+          <div className="dagdo-popover-hint">Completed {formatDate(task.doneAt)}</div>
         )}
       </div>
 
-      <div className="dagdo-panel-row">
-        <div className="dagdo-panel-label">Created</div>
-        <div className="dagdo-panel-value dagdo-panel-created">{formatDate(task.createdAt)}</div>
-        <div className="dagdo-panel-hint dagdo-panel-id">{task.id}</div>
-      </div>
-
-      <div className="dagdo-panel-footer">
-        <button className="dagdo-panel-delete" onClick={onDelete}>
-          Delete task
+      <div className="dagdo-popover-footer">
+        <span className="dagdo-popover-hint dagdo-popover-id" title={task.id}>
+          {formatDate(task.createdAt)}
+        </span>
+        <button className="dagdo-popover-delete" onClick={onDelete}>
+          Delete
         </button>
       </div>
-    </aside>
+    </div>
   );
 }
 

--- a/web/src/TaskPopover.tsx
+++ b/web/src/TaskPopover.tsx
@@ -3,7 +3,7 @@ import type { Priority, Task } from "./types";
 
 interface TaskPopoverProps {
   task: Task;
-  onChange: (patch: { priority?: Priority; tags?: string[]; doneAt?: string | null }) => void;
+  onChange: (patch: { title?: string; priority?: Priority; tags?: string[]; doneAt?: string | null }) => void;
   onDelete: () => void;
   onClose: () => void;
 }
@@ -17,11 +17,34 @@ const PRIORITIES: Priority[] = ["high", "med", "low"];
  */
 export function TaskPopover({ task, onChange, onDelete, onClose }: TaskPopoverProps) {
   const [tagDraft, setTagDraft] = useState("");
+  const [titleDraft, setTitleDraft] = useState(task.title);
 
-  // Reset the tag draft when switching between tasks so input doesn't leak.
+  // Reset input drafts when switching between tasks so nothing leaks across.
   useEffect(() => {
     setTagDraft("");
-  }, [task.id]);
+    setTitleDraft(task.title);
+  }, [task.id, task.title]);
+
+  function commitTitle(): void {
+    const next = titleDraft.trim();
+    if (next.length === 0 || next === task.title) {
+      setTitleDraft(task.title);
+      return;
+    }
+    onChange({ title: next });
+  }
+
+  function onTitleKeyDown(e: KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      e.currentTarget.blur();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      setTitleDraft(task.title);
+      e.currentTarget.blur();
+    }
+  }
 
   function addTag(raw: string): void {
     const tag = raw.trim();
@@ -70,6 +93,22 @@ export function TaskPopover({ task, onChange, onDelete, onClose }: TaskPopoverPr
         <button className="dagdo-popover-close" onClick={onClose} aria-label="Close">
           ✕
         </button>
+      </div>
+
+      <div className="dagdo-popover-row">
+        <div className="dagdo-popover-label">Title</div>
+        <input
+          className="dagdo-popover-input dagdo-popover-input-title"
+          value={titleDraft}
+          onChange={(e) => setTitleDraft(e.target.value)}
+          onKeyDown={onTitleKeyDown}
+          // React Flow listens for Backspace/Delete at the canvas level to
+          // remove selected nodes — stop those keys from bubbling so typing
+          // in the title doesn't delete the task itself.
+          onKeyDownCapture={(e) => e.stopPropagation()}
+          onBlur={commitTitle}
+          aria-label="Task title"
+        />
       </div>
 
       <div className="dagdo-popover-row">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -171,6 +171,17 @@ body,
   min-height: 0;
 }
 
+/* Space-held pan mode: show a grab cursor over the canvas surface and a
+   grabbing cursor while a pan drag is active. We target the React Flow pane
+   directly so node interiors (text, buttons) keep their own cursors. */
+.dagdo-canvas.is-space-down .react-flow__pane {
+  cursor: grab;
+}
+
+.dagdo-canvas.is-space-down .react-flow__pane:active {
+  cursor: grabbing;
+}
+
 /* ─── node ─────────────────────────────────────────────────────────── */
 
 .dagdo-node-body {
@@ -320,30 +331,31 @@ body,
   background: var(--ready);
 }
 
-/* ─── property panel ───────────────────────────────────────────────── */
+/* ─── task popover ────────────────────────────────────────────────── */
 
-.dagdo-panel {
-  width: 300px;
-  min-width: 300px;
-  max-width: 300px;
-  border-left: 1px solid var(--border);
+.dagdo-popover {
+  width: 260px;
+  max-width: 260px;
   background: var(--surface);
-  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-elevated);
   display: flex;
   flex-direction: column;
   font-size: 13px;
   letter-spacing: -0.17px;
+  overflow: hidden;
 }
 
-.dagdo-panel-head {
+.dagdo-popover-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border);
 }
 
-.dagdo-panel-title {
+.dagdo-popover-title {
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 400;
@@ -352,128 +364,111 @@ body,
   color: var(--subtle);
 }
 
-.dagdo-panel-close {
+.dagdo-popover-close {
   background: transparent;
   border: none;
   font-size: 14px;
   color: var(--muted);
   cursor: pointer;
-  padding: 2px 8px;
+  padding: 2px 6px;
   border-radius: 4px;
   line-height: 1;
   transition: background 120ms ease;
 }
 
-.dagdo-panel-close:hover {
+.dagdo-popover-close:hover {
   background: var(--panel);
   color: var(--text);
 }
 
-.dagdo-panel-row {
-  padding: 14px 16px;
+.dagdo-popover-row {
+  padding: 10px 12px;
   border-bottom: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
-.dagdo-panel-label {
+.dagdo-popover-label {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--subtle);
   font-weight: 400;
 }
 
-.dagdo-panel-value {
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: -0.18px;
-}
-
-.dagdo-panel-title-readonly {
-  word-break: break-word;
-  white-space: pre-wrap;
-}
-
-.dagdo-panel-hint {
-  font-size: 12px;
+.dagdo-popover-hint {
+  font-size: 11px;
   color: var(--subtle);
   letter-spacing: -0.15px;
 }
 
-.dagdo-panel-id {
+.dagdo-popover-id {
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0;
 }
 
-.dagdo-panel-created {
-  font-size: 13px;
-  font-weight: 400;
-}
-
-.dagdo-panel-segmented {
+.dagdo-popover-segmented {
   display: flex;
   border: 1px solid var(--border-strong);
   border-radius: 6px;
   overflow: hidden;
 }
 
-.dagdo-panel-seg {
+.dagdo-popover-seg {
   flex: 1;
   font-family: var(--font-body);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   background: var(--surface);
   color: var(--text);
   border: none;
   border-right: 1px solid var(--border-strong);
-  padding: 8px 0;
+  padding: 6px 0;
   cursor: pointer;
   text-transform: capitalize;
   letter-spacing: -0.15px;
   transition: background 120ms ease;
 }
 
-.dagdo-panel-seg:last-child {
+.dagdo-popover-seg:last-child {
   border-right: none;
 }
 
-.dagdo-panel-seg:hover:not(.is-active) {
+.dagdo-popover-seg:hover:not(.is-active) {
   background: var(--panel);
 }
 
-.dagdo-panel-seg.is-active {
+.dagdo-popover-seg.is-active {
   background: var(--ready);
   color: var(--ready-fg);
 }
 
-.dagdo-panel-seg-high::before {
+.dagdo-popover-seg-high::before {
   content: "● ";
   color: var(--pri-high);
 }
-.dagdo-panel-seg-med::before {
+.dagdo-popover-seg-med::before {
   content: "● ";
   color: var(--pri-med);
 }
-.dagdo-panel-seg-low::before {
+.dagdo-popover-seg-low::before {
   content: "● ";
   color: var(--pri-low);
 }
-.dagdo-panel-seg.is-active::before {
+.dagdo-popover-seg.is-active::before {
   color: var(--ready-fg);
 }
 
-.dagdo-panel-tags {
+.dagdo-popover-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
 
-.dagdo-panel-empty {
+.dagdo-popover-empty {
   font-size: 12px;
   color: var(--subtle);
 }
@@ -506,25 +501,25 @@ body,
   color: var(--destructive);
 }
 
-.dagdo-panel-input {
+.dagdo-popover-input {
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: 12px;
   background: var(--surface);
   color: var(--text);
   border: 1px solid var(--border-strong);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: 6px 10px;
   outline: none;
   letter-spacing: -0.17px;
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.dagdo-panel-input:focus {
+.dagdo-popover-input:focus {
   border-color: var(--accent);
   box-shadow: var(--focus-ring);
 }
 
-.dagdo-panel-checkbox {
+.dagdo-popover-checkbox {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -532,35 +527,37 @@ body,
   user-select: none;
 }
 
-.dagdo-panel-checkbox input {
+.dagdo-popover-checkbox input {
   cursor: pointer;
   width: 14px;
   height: 14px;
   accent-color: var(--ready);
 }
 
-.dagdo-panel-footer {
-  margin-top: auto;
-  padding: 14px 16px;
+.dagdo-popover-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
   border-top: 1px solid var(--border);
 }
 
-.dagdo-panel-delete {
-  width: 100%;
+.dagdo-popover-delete {
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   background: var(--surface);
   color: var(--destructive);
   border: 1px solid var(--border-strong);
   border-radius: 6px;
-  padding: 10px;
+  padding: 6px 10px;
   cursor: pointer;
   letter-spacing: -0.17px;
   transition: background 120ms ease, border-color 120ms ease;
 }
 
-.dagdo-panel-delete:hover {
+.dagdo-popover-delete:hover {
   background: var(--destructive-bg);
   border-color: var(--destructive);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -182,6 +182,26 @@ body,
   cursor: grabbing;
 }
 
+/* ─── create-ghost preview ─────────────────────────────────────────── */
+
+/* Dashed semi-transparent outline that follows the cursor while Cmd/Ctrl is
+   held, previewing where a click will drop a new task. Sized to the node's
+   CSS box (at zoom=1); at other zooms the ghost won't perfectly match the
+   resulting node's screen size, but the centre lines up, which is what
+   reviewers actually react to. pointer-events: none so it never blocks the
+   click it's previewing. */
+.dagdo-create-ghost {
+  position: fixed;
+  width: 200px;
+  height: 48px;
+  transform: translate(-50%, -50%);
+  border: 1.5px dashed var(--accent);
+  background: rgba(94, 106, 210, 0.08); /* accent at low alpha */
+  border-radius: 8px;
+  pointer-events: none;
+  z-index: 10;
+}
+
 /* ─── node ─────────────────────────────────────────────────────────── */
 
 .dagdo-node-body {
@@ -219,6 +239,16 @@ body,
   background: var(--panel);
   color: var(--subtle);
   box-shadow: var(--shadow-ring);
+}
+
+/* Draft node: visually continuous with the create-ghost so the click feels
+   like the ghost "solidifying" into an editable input rather than a new
+   element appearing from nowhere. */
+.dagdo-node-draft {
+  background: rgba(94, 106, 210, 0.08);
+  border: 1.5px dashed var(--accent);
+  box-shadow: none;
+  padding: 10px 12px;
 }
 
 .dagdo-node-done .dagdo-node-title {
@@ -517,6 +547,13 @@ body,
 .dagdo-popover-input:focus {
   border-color: var(--accent);
   box-shadow: var(--focus-ring);
+}
+
+/* Title input is the primary text in the popover — bump it up so it reads
+   as more weighty than the tag input below. */
+.dagdo-popover-input-title {
+  font-size: 13px;
+  font-weight: 500;
 }
 
 .dagdo-popover-checkbox {


### PR DESCRIPTION
## Summary

- **Popover editor (#18).** Replace the right-side `PropertyPanel` with a compact popover anchored to the selected node via `@xyflow/react`'s `<NodeToolbar>`. The popover stays anchored through pan/zoom, flips from below-node to above when it would overflow the viewport, and dismisses on Esc, pane-click, or clicking another node. `PropertyPanel.tsx` is deleted; shared chip styles migrate into `.dagdo-popover-*`.
- **Canvas shortcuts (#21).** Space + left-drag pans (grab cursor while held; resets on blur). Cmd (macOS) / Ctrl + click on empty canvas creates a task at the click point via `screenToFlowPosition`. New tasks are tagged in `userPositioned` so SSE reconcile preserves the coordinate.
- README's Web view section gains a Canvas shortcuts list.

Closes #18, closes #21.

## Test plan

- [ ] Click a node → popover opens; edit priority/tags/done → task updates
- [ ] Popover stays anchored while panning/zooming; flips when near viewport edge
- [ ] Esc, pane-click, or clicking another node closes the popover
- [ ] Space+drag pans canvas (grab cursor); release Space resumes normal drag
- [ ] Cmd/Ctrl + empty-canvas click creates a task at the click point; Cmd/Ctrl on a node does NOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)