### PR TITLE
Surface alpha install command on PR and fix check-label race

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -22,6 +22,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Needed to post/update the sticky "alpha published" comment on the
+      # associated PR.
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -32,14 +35,73 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
       - name: Set alpha version
+        id: version
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           BASE_VERSION=$(node -p "require('./package.json').version")
           ALPHA_VERSION="${BASE_VERSION}-alpha.${SHORT_SHA}"
           npm version "$ALPHA_VERSION" --no-git-tag-version
+          echo "alpha=$ALPHA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
           echo "Publishing alpha: $ALPHA_VERSION"
       - run: bun run build:web
       - run: npm install --ignore-scripts
       - run: npm publish --tag alpha --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Comment install command on associated PR
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          ALPHA_VERSION: ${{ steps.version.outputs.alpha }}
+          SHORT_SHA: ${{ steps.version.outputs.short_sha }}
+        with:
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const openPR = prs.find((p) => p.state === 'open');
+            if (!openPR) {
+              core.info('No open PR is associated with this commit yet; skipping comment. It will appear on the next push after the PR is opened.');
+              return;
+            }
+            // Sticky marker — identifies our comment on subsequent pushes so
+            // we update in place instead of spamming one per push.
+            const marker = '<!-- alpha-install-sticky -->';
+            const pkg = require('./package.json').name;
+            const body = [
+              marker,
+              `🧪 **Alpha published** from \`${process.env.SHORT_SHA}\``,
+              '',
+              '```',
+              `npm i -g ${pkg}@${process.env.ALPHA_VERSION}`,
+              '```',
+              '',
+              '_Re-pushing this branch updates the alpha; this comment updates in place._',
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: openPR.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky comment ${existing.id} on PR #${openPR.number}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openPR.number,
+                body,
+              });
+              core.info(`Posted sticky comment on PR #${openPR.number}.`);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,21 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # Also fire on label changes so `check-label` re-runs against the current
+    # labels — otherwise it reads a stale payload from the initial PR-open
+    # event and stays failed even after the label is added.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
     branches: [main]
 
 jobs:
   test:
+    # Label-only events don't touch code, so skip the expensive test job.
+    if: >-
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+       github.event.action != 'labeled' &&
+       github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +29,8 @@ jobs:
       - run: bun test
 
   check-label:
+    # merge_group events have no pull_request payload; the script would crash.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Require version label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Alpha publish workflow now leaves a sticky comment on the associated PR with the `npm i -g @coiggahou2002/dagdo@<version>` command for the just-published alpha. The comment updates in place on every subsequent push, so reviewers can install and smoke-test a branch without hunting through run logs for the version string.
+- Fix `check-label` CI so labels added after PR open take effect — the workflow now also triggers on `labeled` / `unlabeled` events instead of reading a stale payload from the PR-open event. Label-only events skip the `test` job to save runner time; `check-label` itself no longer runs in merge-queue contexts where there is no `pull_request` payload.
+
 ## [0.11.1] - 2026-04-21
 
 - `dagdo ui` now has a 20×20 hit area around each node connection handle (visible dot still 8×8), making it much easier to start a manual edge drag — especially on trackpads and high-DPI displays. Adjacent-rank zones stay well clear with dagre's 70px ranksep, and the node body's double-click-to-edit remains reliable. (#19)


### PR DESCRIPTION
## Summary

Two CI workflow improvements.

### 1. Alpha install command on the PR page

`publish-alpha` now posts a sticky comment on the associated open PR with the full `npm i -g @coiggahou2002/dagdo@<version>` command. A hidden marker (`<!-- alpha-install-sticky -->`) lets subsequent pushes update the existing comment **in place** instead of spamming one per push. Reviewers can install + smoke-test a branch without hunting through run logs for the version string.

Known gap: on the very first push-before-PR-open there is no PR to comment on yet. The next push after the PR is opened restores the comment. (This very PR will demonstrate — I'll push an empty commit after open.)

### 2. Fix `check-label` stale-payload race

`check-label` previously read `context.payload.pull_request.labels` from the PR-open event payload, so labels added after the PR was opened never re-evaluated and the check stayed red. Workarounds so far have been close+reopen.

Fix: add `labeled` / `unlabeled` to `pull_request` trigger types so the workflow fires with a fresh payload when a label is added. As a bonus:
- Skip the expensive `test` job on label-only events
- Gate `check-label` on `github.event_name == 'pull_request'` so it no longer crashes on merge-queue payloads that have no `pull_request` key

## Test plan

- [ ] CI on this PR opens green on the first try (because `gh pr create --label` applied the label atomically), then after merge the fix takes effect for future PRs
- [ ] Push an empty commit after opening this PR → Alpha workflow re-runs and posts the sticky install-command comment
- [ ] Push a second time → comment updates in place (no duplicate)
- [ ] Run \`npm i -g @coiggahou2002/dagdo@<version-from-comment>\` on a dev box → CLI boots with the expected version

🤖 Generated with [Claude Code](https://claude.com/claude-code)