### PR TITLE
README: make current language non-clickable in toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dagdo
 
-[English](README.md) | [中文](README.zh-CN.md)
+English | [中文](README.zh-CN.md)
 
 Dependency-aware todo manager. Tasks form a DAG (directed acyclic graph) — topological sort tells you what to do next.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # dagdo
 
-[English](README.md) | [中文](README.zh-CN.md)
+[English](README.md) | 中文
 
 依赖感知的任务管理器。任务构成一个 DAG（有向无环图）——拓扑排序告诉你下一步该做什么。
 


### PR DESCRIPTION
## Summary

- In the language toggle (`English | 中文`) at the top of both READMEs, the current language is now plain text instead of a link — avoids a self-referencing click.

## Test plan

- [ ] Verify `README.md` shows `English | [中文](README.zh-CN.md)` (English is plain text)
- [ ] Verify `README.zh-CN.md` shows `[English](README.md) | 中文` (中文 is plain text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)