### PR TITLE
Skip alpha publish on workflow/docs-only pushes

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -3,6 +3,12 @@ name: Alpha
 on:
   push:
     branches-ignore: [main]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'skills/**'
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Alpha workflow skips test + publish when a push only touches workflow files, markdown, docs, LICENSE, or skills — avoids wasting CI minutes and publishing identical alpha packages. (#28)
+
 ## [0.14.1] - 2026-04-23
 
 - README: fix stale `dagdo done` / `dagdo next` example output to match actual CLI format, update Features list (add notes, web view, cloud sync, dark mode), fix `dagdo ui` command description, and restructure into "For Humans" / "For Agents" sections with the Claude Code skill install and usage guidance in its own section. (#30)


### PR DESCRIPTION
## Summary

- Add `paths-ignore` to the Alpha workflow so pushes that only touch non-source files (`.github/**`, `**/*.md`, `docs/**`, `LICENSE`, `skills/**`) skip the entire workflow — no wasted CI minutes, no functionally identical alpha tarballs.
- Chose option A from the issue (workflow-level `paths-ignore`) since PR CI (`ci.yml`) already runs tests on PRs, so no coverage is lost on the review path.

Closes #28

## Test plan

- [ ] Push a commit that only touches a `.md` file on a non-main branch — Alpha workflow should not trigger
- [ ] Push a commit that touches `src/` — Alpha workflow should trigger normally
- [ ] Push a commit that touches both `src/` and `.md` — Alpha workflow should trigger (GitHub only skips when **all** paths match `paths-ignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)