### PR TITLE
Support running without Bun for npm install users

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -44,8 +44,9 @@ jobs:
           echo "alpha=$ALPHA_VERSION" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
           echo "Publishing alpha: $ALPHA_VERSION"
+      - run: bun install
       - run: bun run build:web
-      - run: npm install --ignore-scripts
+      - run: bun run build:node
       - run: npm publish --tag alpha --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -47,6 +47,8 @@ jobs:
       - run: bun install
       - run: bun run build:web
       - run: bun run build:node
+      - name: Verify tarball contains dist/cli.js
+        run: npm pack --dry-run 2>&1 | grep 'dist/cli.js' || { echo "dist/cli.js missing from tarball"; exit 1; }
       - run: npm publish --tag alpha --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,8 @@ jobs:
       - run: bun install
       - run: bun run build:web
       - run: bun run build:node
+      - name: Verify tarball contains dist/cli.js
+        run: npm pack --dry-run 2>&1 | grep 'dist/cli.js' || { echo "dist/cli.js missing from tarball"; exit 1; }
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,8 +154,9 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      - run: bun install
       - run: bun run build:web
-      - run: npm install --ignore-scripts
+      - run: bun run build:node
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- npm package now runs on Node.js — no Bun required. CLI entry (`bin/dagdo`) executes a pre-bundled `dist/cli.js` via `node` instead of running TypeScript source via `bun`. Build step (`bun build --target=node`) added to both release and alpha CI. `src/` removed from the published package; `engines` changed from `bun >=1.0.0` to `node >=18`. Development (`bun run dev`) and standalone binary (`bun build --compile`) are unchanged. (#2)
+
 ## [0.14.1] - 2026-04-23
 
 - README: fix stale `dagdo done` / `dagdo next` example output to match actual CLI format, update Features list (add notes, web view, cloud sync, dark mode), fix `dagdo ui` command description, and restructure into "For Humans" / "For Agents" sections with the Claude Code skill install and usage guidance in its own section. (#30)

--- a/bin/dagdo
+++ b/bin/dagdo
@@ -6,4 +6,4 @@ while [ -L "$SOURCE" ]; do
   [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
-exec bun run "$SCRIPT_DIR/../src/cli.ts" "$@"
+exec node "$SCRIPT_DIR/../dist/cli.js" "$@"

--- a/package.json
+++ b/package.json
@@ -5,20 +5,20 @@
   "module": "src/cli.ts",
   "type": "module",
   "files": [
-    "src",
     "bin",
-    "skills",
-    "dist/web"
+    "dist",
+    "skills"
   ],
   "bin": {
     "dagdo": "bin/dagdo"
   },
   "engines": {
-    "bun": ">=1.0.0"
+    "node": ">=18"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",
     "build:web": "cd web && bun install --frozen-lockfile && bun run build",
+    "build:node": "bun build src/cli.ts --target=node --outfile dist/cli.js --external mermaid-isomorphic --external playwright --external @hpcc-js/wasm-graphviz --external @resvg/resvg-js",
     "build": "bash scripts/build.sh",
     "test": "bun test",
     "typecheck": "tsc --noEmit && cd web && bun install --frozen-lockfile && bun run typecheck"


### PR DESCRIPTION
## Summary

- Bundle `src/cli.ts` into `dist/cli.js` via `bun build --target=node` (new `build:node` script) so npm users only need Node.js
- `bin/dagdo` now runs `node dist/cli.js` instead of `bun run src/cli.ts`
- `engines` changed from `bun >=1.0.0` to `node >=18`
- `src/` removed from published `files` (replaced by `dist/` which covers both `dist/cli.js` and `dist/web/`)
- Both release and alpha CI run `build:node` before `npm publish`
- Development (`bun run dev`) and standalone binary (`bun build --compile`) are unchanged

Closes #2

## Test plan

- [x] `bun run build:node` produces `dist/cli.js` (78KB, 32 modules bundled)
- [x] `node dist/cli.js --version` prints correct version
- [x] `node dist/cli.js help` shows full help text
- [x] `node dist/cli.js list` reads and displays tasks correctly
- [x] `bash bin/dagdo --version` works via the updated entry script
- [x] `bun test` — 61 tests pass
- [x] Verify alpha publish in CI bundles `dist/cli.js` and the npm tarball contains it

🤖 Generated with [Claude Code](https://claude.com/claude-code)