### PR TITLE
Popover: replace done checkbox with Done/Delete button pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- `dagdo ui` popover: replace "Mark as done" checkbox with a **Done** primary button (right side of footer) and move **Delete** to a secondary outline button beside it. Already-done tasks show an **Undo** button instead. (#40)
+
 ## [0.15.0] - 2026-04-23
 
 - npm package now runs on Node.js — no Bun required. CLI entry (`bin/dagdo`) executes a pre-bundled `dist/cli.js` via `node` instead of running TypeScript source via `bun`. Build step (`bun build --target=node`) added to both release and alpha CI. `src/` removed from the published package; `engines` changed from `bun >=1.0.0` to `node >=18`. Development (`bun run dev`) and standalone binary (`bun build --compile`) are unchanged. (#2)

--- a/web/src/TaskPopover.tsx
+++ b/web/src/TaskPopover.tsx
@@ -196,32 +196,23 @@ export function TaskPopover({ task, onChange, onDelete, onClose }: TaskPopoverPr
         />
       </div>
 
-      {/* Done */}
-      <div className="mb-3">
-        <label className="flex items-center gap-2 cursor-pointer select-none">
-          <input
-            type="checkbox"
-            checked={done}
-            onChange={(e) => onChange({ doneAt: e.target.checked ? new Date().toISOString() : null })}
-            className="rounded border-border accent-primary h-4 w-4 cursor-pointer"
-          />
-          <span className="text-sm">Mark as done</span>
-        </label>
-        {done && task.doneAt && (
-          <div className="text-xs text-muted-foreground mt-1">
-            Completed {formatDate(task.doneAt)}
-          </div>
-        )}
-      </div>
-
       {/* Footer */}
       <div className="flex items-center justify-between pt-2 border-t border-border">
         <span className="text-xs text-muted-foreground" title={task.id}>
           {formatDate(task.createdAt)}
         </span>
-        <Button variant="destructive" size="sm" onClick={onDelete}>
-          Delete
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={onDelete}>
+            Delete
+          </Button>
+          <Button
+            size="sm"
+            variant={done ? "secondary" : "default"}
+            onClick={() => onChange({ doneAt: done ? null : new Date().toISOString() })}
+          >
+            {done ? "Undo" : "Done"}
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Remove the "Mark as done" checkbox and its "Completed <date>" text
- Footer now shows **Delete** (outline) on the left and **Done** (primary) on the right
- Already-done tasks show **Undo** (secondary) instead of Done

Closes #40

## Test plan

- [ ] Click a node → popover shows Delete (outline) + Done (primary) in footer
- [ ] Click Done → task marked as done, button changes to Undo (secondary)
- [ ] Click Undo → task reverts to active, button changes back to Done (primary)
- [ ] Delete button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)