### PR TITLE
Fix: dagdo ui bundle-not-found when installed via npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: `dagdo ui` failed with "bundle not found" when installed via `npm i -g` because the bundled `dist/cli.js` resolved `import.meta.url` to `dist/` instead of `src/server/`, breaking the relative path to `dist/web/index.html`. Path resolution now tries both layouts (bundled and source) with a fallback.
+
 ## [0.15.0] - 2026-04-23
 
 - npm package now runs on Node.js — no Bun required. CLI entry (`bin/dagdo`) executes a pre-bundled `dist/cli.js` via `node` instead of running TypeScript source via `bun`. Build step (`bun build --target=node`) added to both release and alpha CI. `src/` removed from the published package; `engines` changed from `bun >=1.0.0` to `node >=18`. Development (`bun run dev`) and standalone binary (`bun build --compile`) are unchanged. (#2)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "http";
 import { existsSync, readFileSync, statSync } from "fs";
+import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { globalDataFile, loadGraph, saveGraph } from "../storage";
 import {
@@ -13,10 +14,13 @@ import {
 } from "../graph/mutations";
 import type { GraphData, Priority } from "../types";
 
-// Resolves to <repo-root>/dist/web/index.html in both dev (bun run src/cli.ts)
-// and installed (node_modules/@coiggahou2002/dagdo/...) layouts — src/server/
-// is always two levels above the dist/web sibling.
-const UI_HTML_PATH = fileURLToPath(new URL("../../dist/web/index.html", import.meta.url));
+// Bundled (node dist/cli.js): import.meta.url → dist/cli.js, sibling is dist/web/
+// Source  (bun run src/cli.ts): import.meta.url → src/server/server.ts, two levels up
+const selfDir = dirname(fileURLToPath(import.meta.url));
+const UI_HTML_PATH = [
+  resolve(selfDir, "web", "index.html"),
+  resolve(selfDir, "..", "..", "dist", "web", "index.html"),
+].find(existsSync) ?? resolve(selfDir, "web", "index.html");
 
 export interface StartedServer {
   url: string;


### PR DESCRIPTION
## Summary

- `dagdo ui` failed with "UI bundle not found" when installed via `npm i -g` because the bundled `dist/cli.js` has `import.meta.url` pointing to `dist/`, so the old `../../dist/web/index.html` relative path escapes the package directory.
- Fix: path resolution now tries both layouts — bundled (`<selfDir>/web/index.html`) and source (`<selfDir>/../../dist/web/index.html`) — with a fallback.

Regression from #39 (Node.js compatibility).

## Test plan

- [x] `bun run build:node && bun run build:web` then `node dist/cli.js ui --no-open` → serves HTML (200 OK)
- [x] `bun run src/cli.ts ui --no-open` → still works in dev mode
- [x] Typecheck + 61 tests pass
- [ ] `npm i -g @coiggahou2002/dagdo@<alpha>` then `dagdo ui` → opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)