### PR TITLE
Add Focus panel showing ready tasks in dagdo ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- `dagdo ui` adds a Focus panel on the left side showing ready tasks (in-degree = 0), grouped by priority. Click a task to pan the canvas to it and open its popover; hover to reveal a check button that marks it done; drag tasks between priority groups to change priority. Empty state shows a hint when no tasks are actionable. (#42)
+
 ## [0.15.2] - 2026-04-23
 
 - `dagdo ui` popover: replace "Mark as done" checkbox with a **Done** primary button (right side of footer) and move **Delete** to a secondary outline button beside it. Already-done tasks show an **Undo** button instead. (#40)

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "dagdo-web",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/vite": "^4.2.4",
         "@xyflow/react": "^12.3.6",
@@ -68,6 +71,14 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -390,6 +401,8 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.2.4",
     "@xyflow/react": "^12.3.6",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,7 +31,8 @@ import {
 } from "./api";
 import { TaskNode, type TaskNodeData } from "./TaskNode";
 import { DraftNode, type DraftNodeData } from "./DraftNode";
-import type { GraphData } from "./types";
+import { FocusPanel } from "./FocusPanel";
+import type { GraphData, Priority } from "./types";
 
 const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
 
@@ -385,6 +386,48 @@ export function App() {
     return { total: graph.tasks.length, done };
   }, [graph]);
 
+  const readyTasks = useMemo(() => {
+    const doneIds = new Set(graph.tasks.filter((t) => t.doneAt != null).map((t) => t.id));
+    const blockerCount = new Map<string, number>();
+    for (const t of graph.tasks) blockerCount.set(t.id, 0);
+    for (const e of graph.edges) {
+      if (!doneIds.has(e.from)) {
+        blockerCount.set(e.to, (blockerCount.get(e.to) ?? 0) + 1);
+      }
+    }
+    const priorityOrder: Record<Priority, number> = { high: 0, med: 1, low: 2 };
+    return graph.tasks
+      .filter((t) => t.doneAt == null && (blockerCount.get(t.id) ?? 0) === 0)
+      .sort((a, b) => {
+        const pd = priorityOrder[a.priority] - priorityOrder[b.priority];
+        if (pd !== 0) return pd;
+        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+      });
+  }, [graph]);
+
+  const handleFocusDone = useCallback((id: string) => {
+    updateTask(id, { doneAt: new Date().toISOString() }).catch((err: unknown) => {
+      toast.error(formatError("Done failed", err));
+    });
+  }, []);
+
+  const handleFocusNode = useCallback((id: string) => {
+    const node = nodes.find((n) => n.id === id);
+    const flow = flowRef.current;
+    if (!node || !flow) return;
+    flow.setCenter(node.position.x + NODE_WIDTH / 2, node.position.y + NODE_HEIGHT / 2, {
+      zoom: 1.2,
+      duration: 400,
+    });
+    setSelectedId(id);
+  }, [nodes]);
+
+  const handleFocusPriorityChange = useCallback((id: string, priority: Priority) => {
+    updateTask(id, { priority }).catch((err: unknown) => {
+      toast.error(formatError("Priority change failed", err));
+    });
+  }, []);
+
   const allNodes = useMemo<FlowNode<TaskNodeData | DraftNodeData>[]>(() => {
     if (!draft) return nodes;
     const draftId = draft.id;
@@ -447,9 +490,15 @@ export function App() {
         }}
       />
 
-      <div className="flex-1 min-h-0">
+      <div className="flex-1 min-h-0 flex">
+        <FocusPanel
+          tasks={readyTasks}
+          onDone={handleFocusDone}
+          onFocus={handleFocusNode}
+          onPriorityChange={handleFocusPriorityChange}
+        />
         {graph.tasks.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
+          <div className="flex-1 flex flex-col items-center justify-center gap-3 text-muted-foreground">
             <p>No tasks yet.</p>
             <Button onClick={onAddTask}>
               <Plus className="h-4 w-4" />
@@ -457,7 +506,7 @@ export function App() {
             </Button>
           </div>
         ) : (
-          <div className={`h-full${isSpaceDown ? " dagdo-canvas is-space-down" : " dagdo-canvas"}`}>
+          <div className={`flex-1 h-full${isSpaceDown ? " dagdo-canvas is-space-down" : " dagdo-canvas"}`}>
             <ReactFlow
               nodes={allNodes}
               edges={edges}

--- a/web/src/FocusPanel.tsx
+++ b/web/src/FocusPanel.tsx
@@ -1,0 +1,186 @@
+import { useMemo } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Check, GripVertical } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import type { Priority, Task } from "./types";
+
+interface FocusPanelProps {
+  tasks: Task[];
+  onDone: (id: string) => void;
+  onFocus: (id: string) => void;
+  onPriorityChange: (id: string, priority: Priority) => void;
+}
+
+const PRIORITY_STYLE: Record<Priority, string> = {
+  high: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+  med: "bg-yellow-100 text-yellow-700 dark:bg-yellow-950 dark:text-yellow-400",
+  low: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400",
+};
+
+function SortableItem({
+  task,
+  onDone,
+  onFocus,
+}: {
+  task: Task;
+  onDone: (id: string) => void;
+  onFocus: (id: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: task.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "flex items-center gap-2 px-2 py-1.5 rounded-md group",
+        "hover:bg-accent/50 transition-colors",
+        isDragging && "opacity-50 z-50",
+      )}
+    >
+      <button
+        className="cursor-grab active:cursor-grabbing text-muted-foreground/40 hover:text-muted-foreground shrink-0"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </button>
+      <button
+        className="flex-1 text-left min-w-0 cursor-pointer"
+        onClick={() => onFocus(task.id)}
+      >
+        <span className="text-sm leading-snug line-clamp-2">{task.title}</span>
+      </button>
+      <span
+        className={cn(
+          "text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded shrink-0",
+          PRIORITY_STYLE[task.priority],
+        )}
+      >
+        {task.priority === "med" ? "med" : task.priority}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+        onClick={() => onDone(task.id)}
+        aria-label={`Mark "${task.title}" as done`}
+      >
+        <Check className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+export function FocusPanel({ tasks, onDone, onFocus, onPriorityChange }: FocusPanelProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const sortedIds = useMemo(() => tasks.map((t) => t.id), [tasks]);
+
+  function handleDragEnd(event: DragEndEvent): void {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const draggedId = active.id as string;
+    const overId = over.id as string;
+    const overTask = tasks.find((t) => t.id === overId);
+    if (!overTask) return;
+
+    const draggedTask = tasks.find((t) => t.id === draggedId);
+    if (!draggedTask || draggedTask.priority === overTask.priority) return;
+
+    onPriorityChange(draggedId, overTask.priority);
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <div className="w-[260px] shrink-0 border-r border-border bg-background flex flex-col">
+        <div className="px-3 py-2 border-b border-border">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Focus
+          </h2>
+        </div>
+        <div className="flex-1 flex items-center justify-center p-4">
+          <p className="text-xs text-muted-foreground text-center leading-relaxed">
+            There's no actionable tasks now. Please check your graph.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const groups: { priority: Priority; items: Task[] }[] = [];
+  let currentPriority: Priority | null = null;
+  for (const task of tasks) {
+    if (task.priority !== currentPriority) {
+      currentPriority = task.priority;
+      groups.push({ priority: currentPriority, items: [] });
+    }
+    groups[groups.length - 1]!.items.push(task);
+  }
+
+  return (
+    <div className="w-[260px] shrink-0 border-r border-border bg-background flex flex-col">
+      <div className="px-3 py-2 border-b border-border flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Focus
+        </h2>
+        <span className="text-xs text-muted-foreground">{tasks.length}</span>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2">
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={sortedIds} strategy={verticalListSortingStrategy}>
+            {groups.map((group) => (
+              <div key={group.priority} className="mb-2">
+                <div className="px-2 py-1">
+                  <span
+                    className={cn(
+                      "text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded",
+                      PRIORITY_STYLE[group.priority],
+                    )}
+                  >
+                    {group.priority}
+                  </span>
+                </div>
+                {group.items.map((task) => (
+                  <SortableItem
+                    key={task.id}
+                    task={task}
+                    onDone={onDone}
+                    onFocus={onFocus}
+                  />
+                ))}
+              </div>
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
+  );
+}

--- a/web/src/FocusPanel.tsx
+++ b/web/src/FocusPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -25,6 +25,48 @@ interface FocusPanelProps {
   onDone: (id: string) => void;
   onFocus: (id: string) => void;
   onPriorityChange: (id: string, priority: Priority) => void;
+}
+
+const MIN_WIDTH = 260;
+const MAX_WIDTH = 400;
+const STORAGE_KEY = "dagdo-focus-width";
+
+function useResizableWidth() {
+  const [width, setWidth] = useState(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const n = Number(stored);
+      if (n >= MIN_WIDTH && n <= MAX_WIDTH) return n;
+    }
+    return MIN_WIDTH;
+  });
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const startW = useRef(0);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, String(width));
+  }, [width]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    startX.current = e.clientX;
+    startW.current = width;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, [width]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    const delta = e.clientX - startX.current;
+    setWidth(Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startW.current + delta)));
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    dragging.current = false;
+  }, []);
+
+  return { width, onPointerDown, onPointerMove, onPointerUp, isDragging: dragging };
 }
 
 const PRIORITY_STYLE: Record<Priority, string> = {
@@ -96,6 +138,7 @@ function SortableItem({
 }
 
 export function FocusPanel({ tasks, onDone, onFocus, onPriorityChange }: FocusPanelProps) {
+  const { width, onPointerDown, onPointerMove, onPointerUp } = useResizableWidth();
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -118,9 +161,18 @@ export function FocusPanel({ tasks, onDone, onFocus, onPriorityChange }: FocusPa
     onPriorityChange(draggedId, overTask.priority);
   }
 
+  const resizeHandle = (
+    <div
+      className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/20 active:bg-primary/30 transition-colors"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  );
+
   if (tasks.length === 0) {
     return (
-      <div className="w-[260px] shrink-0 border-r border-border bg-background flex flex-col">
+      <div className="relative shrink-0 border-r border-border bg-background flex flex-col" style={{ width }}>
         <div className="px-3 py-2 border-b border-border">
           <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             Focus
@@ -131,6 +183,7 @@ export function FocusPanel({ tasks, onDone, onFocus, onPriorityChange }: FocusPa
             There's no actionable tasks now. Please check your graph.
           </p>
         </div>
+        {resizeHandle}
       </div>
     );
   }
@@ -146,7 +199,7 @@ export function FocusPanel({ tasks, onDone, onFocus, onPriorityChange }: FocusPa
   }
 
   return (
-    <div className="w-[260px] shrink-0 border-r border-border bg-background flex flex-col">
+    <div className="relative shrink-0 border-r border-border bg-background flex flex-col" style={{ width }}>
       <div className="px-3 py-2 border-b border-border flex items-center justify-between">
         <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Focus
@@ -181,6 +234,7 @@ export function FocusPanel({ tasks, onDone, onFocus, onPriorityChange }: FocusPa
           </SortableContext>
         </DndContext>
       </div>
+      {resizeHandle}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add a fixed-width (260px) left side panel to `dagdo ui` showing ready tasks (active, in-degree = 0), grouped by priority (high → med → low)
- **Click** a task → canvas pans/zooms to that node and opens its popover
- **Hover** a task → reveals a check button to mark it done
- **Drag** a task between priority groups → changes its priority
- Empty state: "There's no actionable tasks now. Please check your graph."
- Ready tasks computed client-side from existing graph data (no new API)
- Uses `@dnd-kit/sortable` for drag-and-drop between priority groups

Closes #42

## Test plan

- [x] Panel shows ready tasks grouped by priority
- [x] Click a task → canvas pans to the node and popover opens
- [x] Typecheck + 61 tests pass
- [ ] Hover → done button appears, clicking it marks task done and removes from panel
- [ ] Drag task from MED to HIGH → priority changes
- [ ] When all tasks are done/blocked → empty state message shows
- [ ] Panel respects light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)