### PR TITLE
Fix dark-mode scrollbar color

### DIFF
--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -100,6 +100,44 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ─── Scrollbar (dark-mode aware) ──────────────────────────────────── */
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: hsl(240 4% 76%);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(240 4% 64%);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: hsl(240 4% 24%);
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: hsl(240 4% 34%);
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(240 4% 76%) transparent;
+}
+
+.dark * {
+  scrollbar-color: hsl(240 4% 24%) transparent;
+}
+
 /* ─── React Flow overrides ──────────────────────────────────────────── */
 
 .react-flow__handle {


### PR DESCRIPTION
## Summary
- Add dark-mode-aware scrollbar styles to `globals.css` so scrollbars blend with the theme instead of showing jarring white tracks
- Webkit browsers get `::-webkit-scrollbar` styling; Firefox gets `scrollbar-color` + `scrollbar-width: thin`

Closes #45

## Test plan
- [ ] Switch to dark mode, trigger a scrollbar (e.g. resize window or add many tasks) — thumb should be subtle dark gray, no white track
- [ ] Switch to light mode — thumb should be a subtle light gray
- [ ] Verify in Firefox (scrollbar-color fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)