### PR TITLE
Fix dark-mode scrollbar color

### DIFF
--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -199,6 +199,15 @@ body {
   stroke-dasharray: 4 4;
 }
 
+/* Light-mode canvas gets a subtle off-white so it doesn't feel flat */
+.dagdo-canvas {
+  background: hsl(240 5% 96%);
+}
+
+.dark .dagdo-canvas {
+  background: transparent;
+}
+
 /* Space+drag pan cursor */
 .dagdo-canvas.is-space-down .react-flow__pane {
   cursor: grab;

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -100,6 +100,43 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ─── Scrollbar (dark-mode aware) ──────────────────────────────────── */
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: hsl(240 4% 76%);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(240 4% 64%);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: hsl(240 4% 24%);
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: hsl(240 4% 34%);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(240 4% 76%) transparent;
+}
+
+.dark * {
+  scrollbar-color: hsl(240 4% 24%) transparent;
+}
+
 /* ─── React Flow overrides ──────────────────────────────────────────── */
 
 .react-flow__handle {


### PR DESCRIPTION
## Summary
- Add dark-mode-aware scrollbar styles to `globals.css` so scrollbars (especially the FocusPanel sidebar) blend with the theme instead of showing jarring white tracks
- Webkit: `::-webkit-scrollbar` with transparent track + theme-matched thumb
- Firefox: `scrollbar-color` + `scrollbar-width: thin`

Closes #45

## Test plan
- [ ] Dark mode — trigger sidebar scrollbar with many tasks, thumb should be subtle dark gray, no white track
- [ ] Light mode — scrollbar thumb should be a subtle light gray
- [ ] Verify in Firefox (scrollbar-color fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)