### PR TITLE
fix(web): new tasks belong to the active tab, not All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: `dagdo ui` — new tasks created while a named tab is active now belong to that tab. Previously they fell into the "All" view because `createTask` didn't pass any tab info, so the task lived outside every tab's `taskIds`. (#52)
+
 ## [0.17.0] - 2026-04-28
 
 ## [0.16.2] - 2026-04-28

--- a/src/graph/mutations.ts
+++ b/src/graph/mutations.ts
@@ -17,6 +17,12 @@ export interface AddTaskArgs {
   title: string;
   priority?: Priority;
   tags?: string[];
+  /**
+   * If set, the new task is also appended to this tab's `taskIds`. Caller is
+   * responsible for validating the tab exists — `addTask` assumes it does and
+   * silently no-ops the membership write if the id isn't found.
+   */
+  tabId?: string;
 }
 
 export function addTask(data: GraphData, args: AddTaskArgs): { data: GraphData; task: Task } {
@@ -28,10 +34,16 @@ export function addTask(data: GraphData, args: AddTaskArgs): { data: GraphData; 
     createdAt: new Date().toISOString(),
     doneAt: null,
   };
-  return {
-    data: { ...data, tasks: [...data.tasks, task] },
-    task,
-  };
+  let next: GraphData = { ...data, tasks: [...data.tasks, task] };
+  if (args.tabId !== undefined && next.tabs) {
+    next = {
+      ...next,
+      tabs: next.tabs.map((t) =>
+        t.id === args.tabId ? { ...t, taskIds: [...t.taskIds, task.id] } : t,
+      ),
+    };
+  }
+  return { data: next, task };
 }
 
 /**

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -172,13 +172,18 @@ async function handleCreateTask(
 
   const priority = (body as Record<string, unknown>).priority;
   const tags = (body as Record<string, unknown>).tags;
+  const tabId = (body as Record<string, unknown>).tabId;
   const args = {
     title: title.trim(),
     priority: isPriority(priority) ? priority : undefined,
     tags: Array.isArray(tags) ? tags.filter((t): t is string => typeof t === "string") : undefined,
+    tabId: typeof tabId === "string" ? tabId : undefined,
   };
 
   const graph = await loadGraph();
+  if (args.tabId !== undefined && !(graph.tabs ?? []).some((t) => t.id === args.tabId)) {
+    return sendJson(res, 404, { error: "tab_not_found", id: args.tabId });
+  }
   const { data, task } = addTask(graph, args);
   await saveGraph(data, `add: ${task.title}`);
   broadcast();

--- a/tests/mutations.test.ts
+++ b/tests/mutations.test.ts
@@ -38,6 +38,25 @@ describe("addTask", () => {
     addTask(input, { title: "t1" });
     expect(input.tasks).toEqual([]);
   });
+
+  it("appends the new task id to the target tab when tabId is given", () => {
+    const input = makeData({
+      tabs: [
+        { id: "tabA", name: "A", taskIds: ["existing"] },
+        { id: "tabB", name: "B", taskIds: [] },
+      ],
+      tasks: [task("existing")],
+    });
+    const { data, task: created } = addTask(input, { title: "t1", tabId: "tabA" });
+    expect(data.tabs?.find((t) => t.id === "tabA")?.taskIds).toEqual(["existing", created.id]);
+    expect(data.tabs?.find((t) => t.id === "tabB")?.taskIds).toEqual([]);
+  });
+
+  it("ignores unknown tabId without throwing", () => {
+    const input = makeData({ tabs: [{ id: "tabA", name: "A", taskIds: [] }] });
+    const { data } = addTask(input, { title: "t1", tabId: "missing" });
+    expect(data.tabs?.[0]?.taskIds).toEqual([]);
+  });
 });
 
 describe("updateTask", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -408,7 +408,10 @@ export function App() {
   const handleDraftCommit = useCallback(
     async (draftId: number, position: { x: number; y: number }, title: string) => {
       try {
-        const task = await createTask({ title });
+        const task = await createTask({
+          title,
+          tabId: activeTabId === DEFAULT_TAB_ID ? undefined : activeTabId,
+        });
         userPositioned.current.add(task.id);
         setNodes((current) => {
           const idx = current.findIndex((n) => n.id === task.id);
@@ -448,7 +451,7 @@ export function App() {
         setDraft((cur) => (cur && cur.id === draftId ? null : cur));
       }
     },
-    [handleRename, handlePatch, handleDelete, handleClosePopover],
+    [activeTabId, tabs, handleRename, handlePatch, handleDelete, handleClosePopover, handleMoveTaskToTab],
   );
 
   const handleDraftCancel = useCallback((draftId: number) => {
@@ -510,12 +513,15 @@ export function App() {
     const trimmed = title.trim();
     if (trimmed.length === 0) return;
     try {
-      const task = await createTask({ title: trimmed });
+      const task = await createTask({
+        title: trimmed,
+        tabId: activeTabId === DEFAULT_TAB_ID ? undefined : activeTabId,
+      });
       toast.success(`Added "${task.title}"`);
     } catch (err) {
       toast.error(formatError("Add failed", err));
     }
-  }, []);
+  }, [activeTabId]);
 
   const stats = useMemo(() => {
     const done = graph.tasks.filter((t) => t.doneAt != null).length;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -50,7 +50,7 @@ async function jsonOrThrow<T>(res: Response): Promise<T> {
   throw new ApiError(kind, body.error ?? `HTTP ${res.status}`, body);
 }
 
-export async function createTask(args: { title: string }): Promise<Task> {
+export async function createTask(args: { title: string; tabId?: string }): Promise<Task> {
   const res = await fetch("/api/tasks", {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

- POST /api/tasks now accepts an optional tabId and appends the new task id to that tab's taskIds. Server validates the tab exists and returns 404 tab_not_found otherwise.
- createTask client API forwards tabId. Both call sites in App.tsx (header New task button and Alt+click draft commit) pass activeTabId when it is not DEFAULT_TAB_ID.
- Tests in tests/mutations.test.ts cover the membership write and the unknown-tabId no-op.

## Test plan

- [ ] Switch to a named tab; click "New task" → task appears immediately in that tab
- [ ] On a named tab, Alt+click the canvas, type a title, hit Enter → draft commits and the new node stays on that tab
- [ ] On the "All" tab, both flows above still work and the new task shows up there (unassigned)
- [ ] Delete the active tab while a create request is in-flight (race) → server rejects with tab_not_found 404 (no orphan task with a missing tabId reference)
- [ ] bun test → all 63 + 2 new = 65 tests pass

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)