### PR TITLE
style(web): edge + ready-node visual polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-- Fix: `dagdo ui` edge contrast — done (dashed) edges now use the muted `--border` color while active (solid) edges use the bolder `--muted-foreground`. The colors were swapped before, so done edges read as more prominent than active ones; now the active relationships stand out and finished ones recede, in both light and dark themes.
+- `dagdo ui` visual polish:
+  - Edge contrast — both active solid and done dashed edges now blend `--muted-foreground` into the background at 45% / 35% so they share a tonal family. Active edges read as the load-bearing structure and done ones recede; previously the colors were swapped (dashed-done was darker than solid-active).
+  - Ready-node accent — the "next to do" nodes (in-degree 0) used to fill with `bg-primary` (near-black in light mode) which clashed with the white blocked nodes around them. Now they share the white card background but get a 2px green border, a soft downward green shadow, a faint green inner tint, and dark-green text — visually emphatic without the harsh black-vs-white contrast.
 
 ## [0.18.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix: `dagdo ui` edge contrast — done (dashed) edges now use the muted `--border` color while active (solid) edges use the bolder `--muted-foreground`. The colors were swapped before, so done edges read as more prominent than active ones; now the active relationships stand out and finished ones recede, in both light and dark themes.
+
 ## [0.18.0] - 2026-04-28
 
 - `dagdo ui` adds a layout-mode toggle in the top-right nav (between the "hide completed" checkbox and the theme button). New default is mindmap mode: the DAG flows left-to-right with edges entering on the left side of each node and exiting on the right (nodes themselves stay horizontal so titles remain readable), and disconnected components stack vertically alongside each other. The previous top-down tree layout is still available via the toggle. Preference persists in `localStorage` (`dagdo-layout-mode`); the view auto-fits after a switch and any user-dragged positions are dropped, since stale coordinates from the other orientation would otherwise pin nodes off-grid.

--- a/web/src/TaskNode.tsx
+++ b/web/src/TaskNode.tsx
@@ -102,7 +102,7 @@ function TaskNodeImpl(props: NodeProps) {
       <div
         className={cn(
           "rounded-lg px-4 py-3 min-w-[160px] max-w-[280px] shadow-sm border cursor-pointer transition-colors",
-          state === "ready" && "bg-primary text-primary-foreground",
+          state === "ready" && "bg-green-500/8 text-green-800 dark:bg-green-400/10 dark:text-green-300 border-2 border-green-500 dark:border-green-400 shadow-[0_8px_20px_-4px_rgba(34,197,94,0.3)] dark:shadow-[0_8px_20px_-4px_rgba(74,222,128,0.3)]",
           state === "blocked" && "bg-card text-card-foreground border-border",
           state === "done" && "bg-muted text-muted-foreground border-border",
         )}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -186,7 +186,7 @@ body {
 }
 
 .react-flow__edge-path {
-  stroke: var(--border) !important;
+  stroke: color-mix(in srgb, var(--muted-foreground) 45%, var(--background)) !important;
   stroke-width: 1.5;
 }
 
@@ -195,7 +195,8 @@ body {
 }
 
 .react-flow__edge.edge-done .react-flow__edge-path {
-  stroke: var(--muted-foreground) !important;
+  stroke: color-mix(in srgb, var(--muted-foreground) 35%, var(--background)) !important;
+  stroke-width: 1.2;
   stroke-dasharray: 4 4;
 }
 


### PR DESCRIPTION
## Summary

Two visual fixes for the canvas, both tuned by iterating against the live UI in light and dark mode.

### 1. Edge contrast

Active solid and done dashed edges had the wrong relationship: done dashed used the darker --muted-foreground while active solid used the lighter --border, so finished relationships read as more prominent than live ones. They now share a tonal family — both blend --muted-foreground into --background — at 45% (active solid, 1.5px) and 35% (done dashed, 1.2px). Active reads as the load-bearing structure of the graph; done recedes.

### 2. Ready-node accent

The in-degree-0 "ready" nodes used bg-primary (near-black in light mode), which clashed with the white blocked nodes and made entire subgraphs look high-contrast. They now share the white card background with the rest, but get:

- 2px green-500 (dark: green-400) border
- 8% / 10% green-tinted inner fill
- deep green text (green-800 / green-300)
- soft downward green drop-shadow (0 8px 20px -4px, 30% alpha)

Color signals "do me next" instead of inverted brightness — emphatic without overpowering.

## Test plan

- [ ] Light mode: ready nodes have green border + soft green drop-shadow, white-ish fill, dark green text. Solid edges visibly stronger than dashed.
- [ ] Dark mode: same accent reads in the dark theme; greens shift to lighter shades, drop-shadow stays subtle.
- [ ] Selected edges still use the bold --foreground stroke (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)