### PR TITLE
feat(web): per-tab badges, Alt+digit shortcuts, scoped focus panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+- `dagdo ui` tab quality-of-life:
+  - Alt + 1..9 jumps between tabs (Alt+1 = the "All" view, Alt+2..9 = first eight named tabs in display order). Cmd+digit is reserved by macOS browsers for the browser's own tab switcher and can't be intercepted, so Alt is used.
+  - Each tab now shows a red badge with its actionable-now count — tasks in that tab that are not done and have no in-tab blocker. Updates live alongside the rest of the graph state.
+  - The Focus side-panel scopes to the active tab. Switching tabs reshapes the panel so it only lists tasks belonging to that tab; the "All" view shows tasks not assigned to any named tab. The header count next to "Focus" matches the badge on the active tab.
+
 ## [0.18.1] - 2026-04-28
 
 - `dagdo ui` visual polish:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,7 +41,27 @@ import { TaskNode, type TaskNodeData } from "./TaskNode";
 import { DraftNode, type DraftNodeData } from "./DraftNode";
 import { FocusPanel } from "./FocusPanel";
 import { TabBar, DEFAULT_TAB_ID } from "./TabBar";
-import type { GraphData, Priority, Tab } from "./types";
+import type { Edge, GraphData, Priority, Tab, Task } from "./types";
+
+/**
+ * "Ready" inside a closed tab subset: not done, and no incoming edge from a
+ * not-yet-done task that's also in the subset. Cross-subset edges are ignored
+ * by construction (they're filtered out before this is called) — the
+ * move-to-tab feature already enforces closed subgraphs, so this only matters
+ * for the default tab when scoping its un-assigned tasks.
+ */
+function computeReady(tasks: Task[], edges: Edge[]): Task[] {
+  const idSet = new Set(tasks.map((t) => t.id));
+  const doneIds = new Set(tasks.filter((t) => t.doneAt != null).map((t) => t.id));
+  const blockerCount = new Map<string, number>();
+  for (const t of tasks) blockerCount.set(t.id, 0);
+  for (const e of edges) {
+    if (!idSet.has(e.from) || !idSet.has(e.to)) continue;
+    if (doneIds.has(e.from)) continue;
+    blockerCount.set(e.to, (blockerCount.get(e.to) ?? 0) + 1);
+  }
+  return tasks.filter((t) => t.doneAt == null && (blockerCount.get(t.id) ?? 0) === 0);
+}
 
 const EMPTY: GraphData = { version: 1, tasks: [], edges: [] };
 
@@ -487,6 +507,38 @@ export function App() {
     [],
   );
 
+  // Alt+1..9 jumps between tabs. Browsers reserve Cmd+1..9 on macOS for the
+  // browser's own tab switcher and won't fire keydown for those, so we use
+  // Alt (Option) — also why the Option-click create-task shortcut sits
+  // beside this without conflict. Alt+1 is the default "All" tab; Alt+2..9
+  // map to named tabs in display order.
+  useEffect(() => {
+    function onTabKey(e: KeyboardEvent): void {
+      if (!e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) return;
+      }
+      const m = /^Digit([1-9])$/.exec(e.code);
+      if (!m) return;
+      const slot = parseInt(m[1]!, 10);
+      e.preventDefault();
+      if (slot === 1) {
+        pendingFitViewRef.current = DEFAULT_TAB_ID;
+        setActiveTabId(DEFAULT_TAB_ID);
+        return;
+      }
+      const tab = tabs[slot - 2];
+      if (tab) {
+        pendingFitViewRef.current = tab.id;
+        setActiveTabId(tab.id);
+      }
+    }
+    window.addEventListener("keydown", onTabKey);
+    return () => window.removeEventListener("keydown", onTabKey);
+  }, [tabs]);
+
   // Space-held pan mode
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent): void {
@@ -551,22 +603,34 @@ export function App() {
   }, [graph]);
 
   const readyTasks = useMemo(() => {
-    const doneIds = new Set(graph.tasks.filter((t) => t.doneAt != null).map((t) => t.id));
-    const blockerCount = new Map<string, number>();
-    for (const t of graph.tasks) blockerCount.set(t.id, 0);
-    for (const e of graph.edges) {
-      if (!doneIds.has(e.from)) {
-        blockerCount.set(e.to, (blockerCount.get(e.to) ?? 0) + 1);
-      }
-    }
     const priorityOrder: Record<Priority, number> = { high: 0, med: 1, low: 2 };
-    return graph.tasks
-      .filter((t) => t.doneAt == null && (blockerCount.get(t.id) ?? 0) === 0)
-      .sort((a, b) => {
-        const pd = priorityOrder[a.priority] - priorityOrder[b.priority];
-        if (pd !== 0) return pd;
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-      });
+    return computeReady(visibleTasks, visibleEdges).sort((a, b) => {
+      const pd = priorityOrder[a.priority] - priorityOrder[b.priority];
+      if (pd !== 0) return pd;
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+  }, [visibleTasks, visibleEdges]);
+
+  // Per-tab "actionable now" counts for the tab-bar badges. Scoping each
+  // tab's edge set to its own task set keeps blockedness consistent with
+  // what the user sees when they switch in.
+  const tabReadyCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    const namedTabs = graph.tabs ?? [];
+    const assignedIds = new Set(namedTabs.flatMap((t) => t.taskIds));
+    const defaultTasks = graph.tasks.filter((t) => !assignedIds.has(t.id));
+    const defaultIdSet = new Set(defaultTasks.map((t) => t.id));
+    const defaultEdges = graph.edges.filter(
+      (e) => defaultIdSet.has(e.from) && defaultIdSet.has(e.to),
+    );
+    counts.set(DEFAULT_TAB_ID, computeReady(defaultTasks, defaultEdges).length);
+    for (const tab of namedTabs) {
+      const idSet = new Set(tab.taskIds);
+      const tabTasks = graph.tasks.filter((t) => idSet.has(t.id));
+      const tabEdges = graph.edges.filter((e) => idSet.has(e.from) && idSet.has(e.to));
+      counts.set(tab.id, computeReady(tabTasks, tabEdges).length);
+    }
+    return counts;
   }, [graph]);
 
   const handleFocusDone = useCallback((id: string) => {
@@ -676,6 +740,7 @@ export function App() {
       <TabBar
         tabs={tabs}
         activeTabId={activeTabId}
+        readyCounts={tabReadyCounts}
         onSelect={handleSelectTab}
         onCreate={handleCreateTab}
         onRename={handleRenameTab}

--- a/web/src/TabBar.tsx
+++ b/web/src/TabBar.tsx
@@ -8,6 +8,8 @@ const DEFAULT_TAB_ID = "__default__";
 interface TabBarProps {
   tabs: Tab[];
   activeTabId: string;
+  /** Per-tab "actionable now" counts, keyed by tab id (and DEFAULT_TAB_ID). */
+  readyCounts: Map<string, number>;
   onSelect: (id: string) => void;
   onCreate: (name: string) => void;
   onRename: (id: string, name: string) => void;
@@ -16,7 +18,7 @@ interface TabBarProps {
 
 export { DEFAULT_TAB_ID };
 
-export function TabBar({ tabs, activeTabId, onSelect, onCreate, onRename, onDelete }: TabBarProps) {
+export function TabBar({ tabs, activeTabId, readyCounts, onSelect, onCreate, onRename, onDelete }: TabBarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -67,6 +69,7 @@ export function TabBar({ tabs, activeTabId, onSelect, onCreate, onRename, onDele
         active={activeTabId === DEFAULT_TAB_ID}
         editing={editingId === DEFAULT_TAB_ID}
         editDraft={editDraft}
+        readyCount={readyCounts.get(DEFAULT_TAB_ID) ?? 0}
         inputRef={editingId === DEFAULT_TAB_ID ? inputRef : undefined}
         onSelect={() => onSelect(DEFAULT_TAB_ID)}
         onDoubleClick={() => {}}
@@ -84,6 +87,7 @@ export function TabBar({ tabs, activeTabId, onSelect, onCreate, onRename, onDele
           active={activeTabId === tab.id}
           editing={editingId === tab.id}
           editDraft={editDraft}
+          readyCount={readyCounts.get(tab.id) ?? 0}
           inputRef={editingId === tab.id ? inputRef : undefined}
           onSelect={() => onSelect(tab.id)}
           onDoubleClick={() => startRename(tab.id, tab.name)}
@@ -114,6 +118,7 @@ interface TabItemProps {
   active: boolean;
   editing: boolean;
   editDraft: string;
+  readyCount: number;
   inputRef?: React.Ref<HTMLInputElement>;
   onSelect: () => void;
   onDoubleClick: () => void;
@@ -129,6 +134,7 @@ function TabItem({
   active,
   editing,
   editDraft,
+  readyCount,
   inputRef,
   onSelect,
   onDoubleClick,
@@ -163,6 +169,14 @@ function TabItem({
         />
       ) : (
         <span className="truncate max-w-[120px]">{name}</span>
+      )}
+      {!editing && readyCount > 0 && (
+        <span
+          className="ml-0.5 min-w-[16px] h-4 px-1 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center leading-none"
+          aria-label={`${readyCount} actionable tasks`}
+        >
+          {readyCount > 99 ? "99+" : readyCount}
+        </span>
       )}
       {closable && !editing && (
         <span


### PR DESCRIPTION
## Summary

Three coordinated tab-ergonomics changes that make working with many tabs feasible:

### 1. Alt + digit jumps between tabs
- Alt+1 → All
- Alt+2..9 → first eight named tabs in display order

Cmd+digit is reserved by macOS browsers for the browser's own tab switcher and never reaches the page, so Alt (Option) is used. Skipped when typing in inputs/textareas.

### 2. Red badge on each tab with actionable-now count
A small unread-style badge shows the count of tasks in that tab that are not done and have no in-tab blocker. Edges that cross outside the tab's task set are ignored when computing in-degree (they should not exist anyway since the move-to-tab feature enforces closed subgraphs, but the scoping is defensive).

### 3. Focus side-panel scopes to the active tab
The left-side Focus panel now lists ready tasks for the current tab only, not the whole graph. The All view shows tasks not assigned to any named tab. The header count next to Focus matches the badge on the active tab.

Refactor: lifts the existing readyTasks computation into a small computeReady(tasks, edges) helper. The focus panel feeds it visibleTasks/visibleEdges (already tab-filtered), and the badge memo runs the same helper per tab.

## Test plan

- [ ] Alt+1 switches to All; Alt+2..9 switch to named tabs by display order
- [ ] Alt+digit while typing in title/notes input is ignored
- [ ] Each tab shows a red badge whose count matches the focus panel header when that tab is active
- [ ] Marking a ready task done decrements its tab's badge live
- [ ] All tab's badge counts only un-assigned tasks; named-tab badges only count tasks in that tab
- [ ] Focus panel only shows tasks from the current tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)